### PR TITLE
Add use_kwargs decorator

### DIFF
--- a/tests/test_bottleparser.py
+++ b/tests/test_bottleparser.py
@@ -78,6 +78,20 @@ def test_use_args_with_url_params(app, testapp):
         return args
     assert testapp.get('/foo/Fred?myvalue=42').json == {'myvalue': 42}
 
+def test_use_kwargs_decorator(app, testapp):
+    @app.route('/foo/', method=['GET', 'POST'])
+    @parser.use_kwargs({'myvalue': Arg(int)})
+    def echo2(myvalue):
+        return {'myvalue': myvalue}
+    assert testapp.post('/foo/', {'myvalue': 23}).json == {'myvalue': 23}
+
+def test_use_kwargs_with_url_params(app, testapp):
+    @app.route('/foo/<name>')
+    @parser.use_kwargs({'myvalue': Arg(int)})
+    def foo(myvalue, name):
+        return {'myvalue': myvalue}
+    assert testapp.get('/foo/Fred?myvalue=42').json == {'myvalue': 42}
+
 def test_parsing_headers(app, testapp):
     @app.route('/echo2')
     def echo2():

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -65,4 +65,6 @@ class BottleParser(core.Parser):
         req_obj = req or request  # Default to context-local request
         return super(BottleParser, self).parse(argmap, req_obj, *args, **kwargs)
 
-use_args = BottleParser().use_args
+parser = BottleParser()
+use_args = parser.use_args
+use_kwargs = parser.use_kwargs

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -202,7 +202,7 @@ class Parser(object):
             else:
                 self.handle_error(error)
 
-    def use_args(self, argmap, req=None, targets=DEFAULT_TARGETS):
+    def use_args(self, argmap, req=None, targets=DEFAULT_TARGETS, as_kwargs=False):
         """Decorator that injects parsed arguments into a view function or method.
 
         Example usage with Flask: ::
@@ -219,9 +219,17 @@ class Parser(object):
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 parsed_args = self.parse(argmap, req=req, targets=targets)
-                return func(parsed_args, *args, **kwargs)
+                if as_kwargs:
+                    kwargs.update(parsed_args)
+                    return func(*args, **kwargs)
+                else:
+                    return func(parsed_args, *args, **kwargs)
             return wrapper
         return decorator
+
+    def use_kwargs(self, *args, **kwargs):
+        kwargs['as_kwargs'] = True
+        return self.use_args(*args, **kwargs)
 
     # Abstract Methods
 

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -214,6 +214,7 @@ class Parser(object):
 
         :param dict argmap: Dictionary of argument_name:Arg object pairs.
         :param tuple targets: Where on the request to search for values.
+        :param bool as_kwargs: Whether to insert arguments as keyword arguments.
         """
         def decorator(func):
             @functools.wraps(func)
@@ -228,6 +229,17 @@ class Parser(object):
         return decorator
 
     def use_kwargs(self, *args, **kwargs):
+        """Decorator that injects parsed arguments into a view function or method as keyword arguments.
+
+        This is a shortcut to :py:func:`use_args` with as_kwargs=True
+
+        Example usage with Flask: ::
+
+            @app.route('/echo', methods=['get', 'post'])
+            @parser.use_kwargs({'name': Arg(type_=str)})
+            def greet(name):
+                return 'Hello ' + name
+        """
         kwargs['as_kwargs'] = True
         return self.use_args(*args, **kwargs)
 

--- a/webargs/djangoparser.py
+++ b/webargs/djangoparser.py
@@ -81,4 +81,6 @@ class DjangoParser(core.Parser):
             return wrapper
         return decorator
 
-use_args = DjangoParser().use_args
+parser = DjangoParser()
+use_args = parser.use_args
+use_kwargs = parser.use_kwargs

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -84,5 +84,6 @@ class FlaskParser(core.Parser):
         req_obj = req or request  # Default to context-local request
         return super(FlaskParser, self).parse(argmap, req_obj, *args, **kwargs)
 
-
-use_args = FlaskParser().use_args
+parser = FlaskParser()
+use_args = parser.use_args
+use_kwargs = parser.use_kwargs


### PR DESCRIPTION
This will allow:

``` py

@app.route('/echo', methods=['get', 'post'])
@parser.use_kwargs({'name': Arg(type_=str)})
def greet(name):
    return 'Hello ' + name
```
