### PR TITLE
Tornado

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,4 +4,4 @@ Credits
 
 * Steven Loria <sloria1@gmail.com>
 * @venuatu <https://github.com/venuatu>
-
+* Javier Santacruz @jvrsantacruz <javier.santacruz.lc@gmail.com>

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ mock
 webtest
 Django>=1.6.2
 bottle>=0.12.3
+tornado

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ and, optionally:
 - Flask
 - Django
 - Bottle
+- Tornado
 
 
 Why Use It
@@ -237,6 +238,58 @@ When using the ``use_args`` decorator, the arguments dictionary will always be t
           return render_to_response('post_template.html',
                                     {'post': blog_post})
 
+Tornado Support
+===============
+
+Tornado argument parsing is available via the :mod:`webargs.tornadoparser` module.
+
+Only a `tornado.httpserver.HTTPRequest` object is needed to parse all needed
+arguments, but it can also be used on a handler function directly by using the
+:meth:`webargs.tornadoparser.Parser.use_args` or :meth:`webargs.tornadoparser.Parser.use_kwargs` decorators.
+
+
+.. code-block:: python
+
+    from webargs import Arg
+    from webargs.tornadoparser import parser
+
+    account_args = {
+        'username': Arg(str),
+        'password': Arg(str)
+    }
+
+    ...
+
+    def get(self):
+        parsed_args = parser.parse(account_args, self.request)
+
+
+Decorator Usage
+---------------
+
+When using the :meth:`webargs.tornadoparser.Parser.use_args`, the decorated
+function will get an extra positional argument at the begining.
+
+.. code-block:: python
+
+    import tornado
+    from webargs import Arg
+    from webargs.tornadoparser import use_args
+
+    account_args = {
+        'username': Arg(str),
+        'password': Arg(str)
+    }
+
+    @use_args(account_args)
+    class Handler(tornado.web.RequestHandler):
+        def get(self, parsed_args):
+            self.write('Hello')
+
+
+With :meth:`webargs.tornadoparser.Parser.use_args`, the parsed arguments will
+go through the ``**kwargs`` dictionary.
+
 API Reference
 =============
 
@@ -272,6 +325,12 @@ webargs.bottleparser
 --------------------
 
 .. automodule:: webargs.bottleparser
+    :inherited-members:
+
+webargs.tornadoparser
+---------------------
+
+.. automodule:: webargs.tornadoparser
     :inherited-members:
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools.command.test import test as TestCommand
 
 # Requirements
 REQUIREMENTS = []
-TEST_REQUIREMENTS =['pytest', 'mock', 'flask', 'django', 'webtest', 'bottle']
+TEST_REQUIREMENTS =['pytest', 'mock', 'flask', 'django', 'webtest', 'bottle', 'tornado']
 
 class PyTest(TestCommand):
     def finalize_options(self):

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -1,0 +1,422 @@
+# -*- coding: utf-8 -*-
+
+import json
+import itertools
+try:
+    from urllib import urlencode  # python2
+except ImportError:
+    from urllib.parse import urlencode  # python3
+
+import pytest
+
+import tornado.web
+import tornado.httputil
+import tornado.httpserver
+
+from webargs import Arg
+from webargs.tornadoparser import parser, use_args, use_kwargs
+
+
+class TestQueryArgs(object):
+    def test_it_should_get_single_values(self):
+        query = [(name, value)]
+        arg = Arg(multiple=False)
+        request = make_get_request(query)
+
+        result = parser.parse_querystring(request, name, arg)
+
+        assert result == bvalue
+
+    def test_it_should_get_multiple_values(self):
+        query = [(name, value), (name, value)]
+        arg = Arg(multiple=True)
+        request = make_get_request(query)
+
+        result = parser.parse_querystring(request, name, arg)
+
+        assert result == [bvalue, bvalue]
+
+    def test_it_should_return_none_if_not_present(self):
+        query = []
+        arg = Arg(multiple=False)
+        request = make_get_request(query)
+
+        result = parser.parse_querystring(request, name, arg)
+
+        assert result == None
+
+    def test_it_should_return_empty_list_if_multiple_and_not_present(self):
+        query = []
+        arg = Arg(multiple=True)
+        request = make_get_request(query)
+
+        result = parser.parse_querystring(request, name, arg)
+
+        assert result == []
+
+
+class TestFormArgs(object):
+    def test_it_should_get_single_values(self):
+        query = [(name, value)]
+        arg = Arg(multiple=False)
+        request = make_form_request(query)
+
+        result = parser.parse_form(request, name, arg)
+
+        assert result == bvalue
+
+    def test_it_should_get_multiple_values(self):
+        query = [(name, value), (name, value)]
+        arg = Arg(multiple=True)
+        request = make_form_request(query)
+
+        result = parser.parse_form(request, name, arg)
+
+        assert result == [bvalue, bvalue]
+
+    def test_it_should_return_none_if_not_present(self):
+        query = []
+        arg = Arg(multiple=False)
+        request = make_form_request(query)
+
+        result = parser.parse_form(request, name, arg)
+
+        assert result == None
+
+    def test_it_should_return_empty_list_if_multiple_and_not_present(self):
+        query = []
+        arg = Arg(multiple=True)
+        request = make_form_request(query)
+
+        result = parser.parse_form(request, name, arg)
+
+        assert result == []
+
+
+class TestJSONArgs(object):
+    def test_it_should_get_single_values(self):
+        query = {name: value}
+        arg = Arg(multiple=False)
+        request = make_json_request(query)
+
+        parser._parse_json_body(request)
+        result = parser.parse_json(request, name, arg)
+
+        assert result == value
+
+    def test_it_should_get_multiple_values(self):
+        query = {name: [value, value]}
+        arg = Arg(multiple=True)
+        request = make_json_request(query)
+
+        parser._parse_json_body(request)
+        result = parser.parse_json(request, name, arg)
+
+        assert result == [value, value]
+
+    def test_it_should_return_none_if_not_present(self):
+        query = {}
+        arg = Arg(multiple=False)
+        request = make_json_request(query)
+
+        parser._parse_json_body(request)
+        result = parser.parse_json(request, name, arg)
+
+        assert result == None
+
+    def test_it_should_return_empty_list_if_multiple_and_not_present(self):
+        query = {}
+        arg = Arg(multiple=True)
+        request = make_json_request(query)
+
+        parser._parse_json_body(request)
+        result = parser.parse_json(request, name, arg)
+
+        assert result == []
+
+
+class TestHeadersArgs(object):
+    def test_it_should_get_single_values(self):
+        query = {name: value}
+        arg = Arg(multiple=False)
+        request = make_request(headers=query)
+
+        result = parser.parse_headers(request, name, arg)
+
+        assert result == value
+
+    def test_it_should_get_multiple_values(self):
+        query = {name: [value, value]}
+        arg = Arg(multiple=True)
+        request = make_request(headers=query)
+
+        result = parser.parse_headers(request, name, arg)
+
+        assert result == [value, value]
+
+    def test_it_should_return_none_if_not_present(self):
+        query = {}
+        arg = Arg(multiple=False)
+        request = make_request(headers=query)
+
+        result = parser.parse_headers(request, name, arg)
+
+        assert result == None
+
+    def test_it_should_return_empty_list_if_multiple_and_not_present(self):
+        query = {}
+        arg = Arg(multiple=True)
+        request = make_request(headers=query)
+
+        result = parser.parse_headers(request, name, arg)
+
+        assert result == []
+
+
+class TestFilesArgs(object):
+    def test_it_should_get_single_values(self):
+        query = [(name, value)]
+        arg = Arg(multiple=False)
+        request = make_files_request(query)
+
+        result = parser.parse_files(request, name, arg)
+
+        assert result == value
+
+    def test_it_should_get_multiple_values(self):
+        query = [(name, value), (name, value)]
+        arg = Arg(multiple=True)
+        request = make_files_request(query)
+
+        result = parser.parse_files(request, name, arg)
+
+        assert result == [value, value]
+
+    def test_it_should_return_none_if_not_present(self):
+        query = []
+        arg = Arg(multiple=False)
+        request = make_files_request(query)
+
+        result = parser.parse_files(request, name, arg)
+
+        assert result == None
+
+    def test_it_should_return_empty_list_if_multiple_and_not_present(self):
+        query = []
+        arg = Arg(multiple=True)
+        request = make_files_request(query)
+
+        result = parser.parse_files(request, name, arg)
+
+        assert result == []
+
+
+class TestErrorHandler(object):
+    def test_it_should_fail_with_bad_request_on_error(self):
+        with pytest.raises(tornado.web.HTTPError) as error:
+            parser.parse(None, make_request())
+
+
+class TestParse(object):
+    def test_it_should_parse_query_arguments(self):
+        attrs = {
+            'string': Arg(),
+            'integer': Arg(int, multiple=True)
+        }
+
+        request = make_get_request([
+            ('string', 'value'),('integer', '1'), ('integer', '2')
+        ])
+
+        parsed = parser.parse(attrs, request)
+
+        assert parsed['integer'] == [1, 2]
+        assert parsed['string'] == bvalue
+
+    def test_it_should_parse_form_arguments(self):
+        attrs = {
+            'string': Arg(),
+            'integer': Arg(int, multiple=True)
+        }
+
+        request = make_form_request([
+            ('string', 'value'),('integer', '1'), ('integer', '2')
+        ])
+
+        parsed = parser.parse(attrs, request)
+
+        assert parsed['integer'] == [1, 2]
+        assert parsed['string'] == bvalue
+
+    def test_it_should_parse_json_arguments(self):
+        attrs = {
+            'string': Arg(str),
+            'integer': Arg(int, multiple=True)
+        }
+
+        request = make_json_request({
+            'string': 'value',
+            'integer': [1, 2]
+        })
+
+        parsed = parser.parse(attrs, request)
+
+        assert parsed['integer'] == [1, 2]
+        assert parsed['string'] == value
+
+    def test_it_should_parse_header_arguments(self):
+        attrs = {
+            'string': Arg(str),
+            'integer': Arg(int, multiple=True)
+        }
+
+        request = make_request(headers={
+            'string': 'value',
+            'integer': ['1', '2']
+        })
+
+        parsed = parser.parse(attrs, request, targets=['headers'])
+
+        assert parsed['string'] == value
+        assert parsed['integer'] == [1, 2]
+
+    def test_it_should_parse_cookies_arguments(self):
+        attrs = {
+            'string': Arg(str),
+            'integer': Arg(int, multiple=True)
+        }
+
+        request = make_cookie_request([
+            ('string', 'value'),('integer', '1'), ('integer', '2')
+        ])
+
+        parsed = parser.parse(attrs, request, targets=['cookies'])
+
+        assert parsed['string'] == value
+        assert parsed['integer'] == [2]
+
+    def test_it_should_parse_files_arguments(self):
+        attrs = {
+            'string': Arg(str),
+            'integer': Arg(int, multiple=True)
+        }
+
+        request = make_files_request([
+            ('string', 'value'),('integer', '1'), ('integer', '2')
+        ])
+
+        parsed = parser.parse(attrs, request, targets=['files'])
+
+        assert parsed['string'] == value
+        assert parsed['integer'] == [1, 2]
+
+
+class TestUseArgs(object):
+    def test_it_should_pass_parsed_as_first_argument(self):
+        class Handler(object):
+            request = make_json_request({'key': 'value'})
+
+            @use_args({'key': Arg()})
+            def get(self, *args, **kwargs):
+                assert args[0] == {'key': 'value'}
+                assert kwargs == {}
+                return True
+
+        handler = Handler()
+        result = handler.get()
+
+        assert result is True
+
+    def test_it_should_pass_parsed_as_kwargs_arguments(self):
+        class Handler(object):
+            request = make_json_request({'key': 'value'})
+
+            @use_kwargs({'key': Arg()})
+            def get(self, *args, **kwargs):
+                assert args == ()
+                assert kwargs == {'key': 'value'}
+                return True
+
+        handler = Handler()
+        result = handler.get()
+
+        assert result is True
+
+
+name = 'name'
+bvalue = b'value'
+value = 'value'
+
+
+def make_uri(args):
+    return '/test?' + urlencode(args)
+
+
+def make_form_body(args):
+    return urlencode(args)
+
+
+def make_json_body(args):
+    return json.dumps(args)
+
+
+def make_get_request(args):
+    return make_request(uri=make_uri(args))
+
+
+def make_form_request(args):
+    return make_request(
+        body=make_form_body(args),
+        headers={
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+    )
+
+
+def make_json_request(args):
+    return make_request(
+        body=make_json_body(args),
+        headers={
+            'Content-Type': 'application/json'
+        }
+    )
+
+
+def make_cookie_request(args):
+    return make_request(
+        headers={
+            'Cookie': ' ;'.join('='.join(pair) for pair in args)
+        }
+    )
+
+
+def make_files_request(args):
+    files = {}
+
+    for key, value in args:
+        if isinstance(value, list):
+            files.setdefault(key, []).extend(value)
+        else:
+            files.setdefault(key, []).append(value)
+
+    return make_request(files=files)
+
+
+def make_request(uri=None, body=None, headers=None, files=None):
+    uri = uri if uri is not None else u''
+    body = body if body is not None else u''
+    method = 'POST' if body else 'GET'
+
+    request = tornado.httpserver.HTTPRequest(
+        method=method, uri=uri, body=body, headers=headers, files=files)
+
+    content_type = headers.get('Content-Type', u'') if headers else u''
+
+    tornado.httputil.parse_body_arguments(
+        content_type=content_type,
+        body=body.encode('latin-1'),  # Tornado expects bodies to be latin-1
+        arguments=request.body_arguments,
+        files=request.files
+    )
+
+    return request

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,6 @@ deps=
     django
     webtest
     bottle
+    tornado
 commands=
     py.test

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+import json
+import functools
+
+import tornado.web
+
+from webargs import core
+
+
+class TornadoParser(core.Parser):
+    """Tornado request argument parser."""
+
+    def parse_json(self, req, name, arg):
+        """Pull a json value from the request."""
+        return self.json.get(name, [] if arg.multiple else None)
+
+    def parse_querystring(self, req, name, arg):
+        """Pull a querystring value from the request."""
+        return get_value(req.query_arguments, name, arg.multiple)
+
+    def parse_form(self, req, name, arg):
+        """Pull a form value from the request."""
+        return get_value(req.body_arguments, name, arg.multiple)
+
+    def parse_headers(self, req, name, arg):
+        """Pull a value from the header data."""
+        return get_value(req.headers, name, arg.multiple)
+
+    def parse_cookies(self, req, name, arg):
+        """Pull a value from the header data."""
+        cookie = req.cookies.get(name)
+
+        if cookie is not None:
+            return [cookie.value] if arg.multiple else cookie.value
+        else:
+            return [] if arg.multiple else None
+
+    def parse_files(self, req, name, arg):
+        """Pull a file from the request."""
+        return get_value(req.files, name, arg.multiple)
+
+    def handle_error(self, error):
+        """Handles errors during parsing. Raises a `tornado.web.HTTPError`
+        with a 400 error.
+        """
+        raise tornado.web.HTTPError(400, error)
+
+    def _parse_json_body(self, req):
+        if req.headers.get('Content-Type') == 'application/json':
+            self.json = json.loads(req.body)
+        else:
+            self.json = {}
+
+    def parse(self, argmap, req, *args, **kwargs):
+        """Parses the request using the given arguments map.
+
+        Initializes :attr:`json` attribute.
+        """
+        self._parse_json_body(req)
+        return super(TornadoParser, self).parse(argmap, req, *args, **kwargs)
+
+    def use_args(self, argmap, req=None, targets=core.DEFAULT_TARGETS, as_kwargs=False):
+        """Decorator that injects parsed arguments into a view function or method.
+
+        Example: ::
+
+            @parser.use_kwargs({'name': Arg(type_=str)})
+            def myview(request, args):
+                self.write('Hello ' + args['name'])
+
+        :param dict argmap: Dictionary of argument_name:Arg object pairs.
+        :param req: The request object to parse
+        :param tuple targets: Where on the request to search for values.
+        :param as_kwargs: Wether to pass arguments to the handler as kwargs
+        """
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(obj, *args, **kwargs):
+                parsed_args = self.parse(
+                    argmap, req=obj.request, targets=targets)
+
+                if as_kwargs:
+                    kwargs.update(parsed_args)
+                else:
+                    args = (parsed_args,) + args
+
+                return func(obj, *args, **kwargs)
+            return wrapper
+        return decorator
+
+
+def get_value(d, name, multiple):
+    """Handle gets from 'multidicts' made of lists
+
+    It handles cases: `{"key": [value]}` and `{"key": value}`
+    """
+    value = d.get(name)
+
+    if multiple:
+        return [] if value is None else value
+
+    if value and isinstance(value, list):
+        return value[0]
+
+    return value
+
+
+parser = TornadoParser()
+use_args = parser.use_args
+use_kwargs = parser.use_kwargs


### PR DESCRIPTION
## Webargs for Tornado

First of all, good work man!

I really like this way of parsing arguments, and I've been already using it for a while in my own `Flask` projects. As it happens, we use `Tornado` at work for some extensive apis and finding/parsing/handling arguments it's getting sparse and annoying; so we decided to contribute :)

This series of commits implements (hopefully) all the parser interface to extract arguments from a `Tornado` request. This includes the `use_args` and `use_kwargs` decorators.
- Working fine for `2.6`, `2.7` and `3.3`
- Also tested successfully for  `3.4` and `pypy`

Hope nothing is amiss,
Javier
