### PR TITLE
Fix error handing in Tornado parser.

### DIFF
--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -79,7 +79,7 @@ class TornadoParser(core.Parser):
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`
         with a 400 error.
         """
-        raise tornado.web.HTTPError(400, error)
+        raise tornado.web.HTTPError(400, error.message)
 
     def _parse_json_body(self, req):
         content_type = req.headers.get('Content-Type')

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -79,7 +79,7 @@ class TornadoParser(core.Parser):
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`
         with a 400 error.
         """
-        raise tornado.web.HTTPError(400, error.message)
+        raise tornado.web.HTTPError(400, error.args[0])
 
     def _parse_json_body(self, req):
         content_type = req.headers.get('Content-Type')


### PR DESCRIPTION
The second argument to tornado.web.HTTPError, log_message, is expected
to be a string, but TornadoParser#handle_error was passing an Exception
object instead, which caused Tornado applications to time out. This
patch sends the message of the exception rather than the exception
itself, and adds a test case that also times out if the wrong argument
is passed to HTTPError.
