### PR TITLE
Add optional source parameter to Arg.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -104,7 +104,14 @@ def test_parse_json_called_by_parse_arg(parse_json, request):
     arg = Arg()
     p = Parser()
     p.parse_arg('foo', arg, request)
-    assert parse_json.called
+    parse_json.assert_called_with(request, 'foo', arg)
+
+@mock.patch('webargs.core.Parser.parse_json')
+def test_parse_json_called_with_source(parse_json, request):
+    arg = Arg(source='bar')
+    p = Parser()
+    p.parse_arg('foo', arg, request)
+    parse_json.assert_called_with(request, 'bar', arg)
 
 @mock.patch('webargs.core.Parser.parse_querystring')
 def test_parse_querystring_called_by_parse_arg(parse_querystring, request):
@@ -319,3 +326,12 @@ def test_full_input_validator_receives_nonascii_input(request):
     args = {'text': Arg(unicode)}
     with pytest.raises(ValidationError):
         parser.parse(args, request, targets=('json', ), validate=validate)
+
+def test_parse_with_source(request):
+
+    request.json = {'foo': 41, 'bar': 42}
+
+    parser = MockRequestParser()
+    args = {'foo': Arg(int), 'baz': Arg(int, source='bar')}
+    parsed = parser.parse(args, request, targets=('json',))
+    assert parsed == {'foo': 41, 'baz': 42}

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -95,13 +95,15 @@ class Arg(object):
     :param bool allow_missing: If the argument is not found on the request,
         don't include it in the parsed arguments dictionary.
     :param str target: Where to pull the value off the request, e.g. ``'json'``.
+    :param str source: Key at which value is located, if different from key in
+        argmap
 
     .. versionchanged:: 0.5.0
         The ``use`` callable is called before type conversion.
     """
     def __init__(self, type_=None, default=None, required=False,
                  validate=None, use=None, multiple=False, error=None,
-                 allow_missing=False, target=None):
+                 allow_missing=False, target=None, source=None):
         self.type = type_ or noop  # default to no type conversion
         if multiple and default is None:
             self.default = []
@@ -116,6 +118,7 @@ class Arg(object):
             raise ValueError('"required" and "allow_missing" cannot both be True.')
         self.allow_missing = allow_missing
         self.target = target
+        self.source = source
 
     def _validate(self, value):
         """Perform conversion and validation on ``value``."""
@@ -201,7 +204,7 @@ class Parser(object):
                 function = func
             else:
                 function = getattr(self, func)
-            value = function(req, name, argobj)
+            value = function(req, argobj.source or name, argobj)
         else:
             value = None
         return value


### PR DESCRIPTION
For use when values are keyed on variable-unsafe names, or when the developer just wants to rename keys:

``` python
args = {
    'content_length': Arg(source='Content-Length'),
    'query': Arg(source='q'),
}
```
