### PR TITLE
Handle TypeError on parsing JSON.

### DIFF
--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -95,7 +95,7 @@ class TornadoParser(core.Parser):
         if content_type and 'application/json' in req.headers.get('Content-Type'):
             try:
                 self.json = parse_json(req.body)
-            except ValueError:
+            except (TypeError, ValueError):
                 self.json = {}
         else:
             self.json = {}


### PR DESCRIPTION
In Tornado, request.body is normally a string, but it can be a
concurrent.Future on streaming requests. This means we also have to
handle TypeErrors on parsing JSON.
