### PR TITLE
Store the argument name inside the exception object.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,5 +18,4 @@ tornado>=4.0
 pyramid>=1.5.2
 
 # Syntax checking
-pep8==1.6.1
-flake8>=2.2.2
+flake8==2.4.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,6 +62,12 @@ class TestArg:
         with pytest.raises(ValidationError):
             arg.validated('foo', 32)
 
+    def test_validated_stores_the_arg_name(self):
+        arg = Arg(validate=lambda t: False)
+        with pytest.raises(ValidationError) as excinfo:
+            arg.validated('our_arg_name', True)
+        assert 'our_arg_name' == excinfo.value.arg_name
+
     def test_validated_with_nonascii_input(self):
         arg = Arg(validate=lambda t: False)
         text = u'øˆ∆´ƒº'

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -40,10 +40,10 @@ class ValidationError(WebargsError):
 
         Store status_code and additonal data.
     """
-    def __init__(self, error, status_code=400, **data):
+    def __init__(self, error, status_code=400, arg_name=None, **data):
         self.message = text_type(error)
         self.status_code = status_code
-        self.arg_name = data.pop('arg_name') if 'arg_name' in data else None
+        self.arg_name = arg_name
         self.data = data
         super(ValidationError, self).__init__(self.message)
 


### PR DESCRIPTION
This should fix #34 

I can see @alexmic suggested we should store also the value of the argument.
My opinion is that this is not a good idea. Especially if we want to validate files or payloads of bigger sizes (consider a dict, base64 hash, etc...)

Let me know if you think that won't be an issue.

Thanks in advance for reviewing this.
