### PR TITLE
Use the parser's locations in `use_args`

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -636,6 +636,21 @@ def test_use_args(web_request, parser):
         return args
     assert viewfunc() == {'username': 'foo', 'password': 'bar'}
 
+def test_use_args_with_custom_locations_in_parser(web_request, parser):
+    custom_args = {
+        'foo': Arg(str),
+    }
+    web_request.json = {}
+    parser.locations = ('custom',)
+    @parser.location_handler('custom')
+    def parse_custom(req, name, arg):
+        return "bar"
+
+    @parser.use_args(custom_args, web_request)
+    def viewfunc(args):
+        return args
+    assert viewfunc() == {'foo': "bar"}
+
 def test_use_kwargs(web_request, parser):
     user_args = {
         'username': Arg(str),

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -442,7 +442,7 @@ class Parser(object):
             of parsed arguments. If the function returns ``False``, the parser
             will raise a :exc:`ValidationError`.
         """
-        locations = locations or self.DEFAULT_LOCATIONS
+        locations = locations or self.locations
 
         def decorator(func):
             @functools.wraps(func)


### PR DESCRIPTION
Fixes https://github.com/sloria/webargs/issues/44
