### PR TITLE
Pyramid request matchdict support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -505,6 +505,19 @@ When using the :meth:`use_args <webargs.pyramidparser.PyramidParser.use_args>` d
 
 As with the other parser modules, :meth:`use_kwargs <webargs.pyramidparser.PyramidParser.use_kwargs>` will add keyword arguments to the view callable.
 
+URL Matches
+-----------
+
+The :mod:`webargs.pyramidparser` module adds support for parsing values from the request matchdict.
+
+.. code-block:: python
+
+    from pyramid.response import Response
+    from webargs.pyramidparser import use_args
+
+    @parser.use_args({'mymatch': Arg(int)}, locations=('matchdict',))
+    def matched(request, args):
+        return Response('The value for mymatch is {}'.format(args['mymatch'])))
 
 API Reference
 =============

--- a/tests/test_pyramidparser.py
+++ b/tests/test_pyramidparser.py
@@ -65,6 +65,10 @@ def testapp():
     def baz(request, myvalue):
         return {'myvalue': myvalue}
 
+    @parser.use_args({'mymatch': Arg(int)}, locations=('matchdict',))
+    def matched(request, args):
+        return args
+
     config = Configurator()
 
     config.add_route('echo', '/echo')
@@ -76,6 +80,7 @@ def testapp():
     config.add_route('foo', '/foo')
     config.add_route('bar', '/bar')
     config.add_route('baz', '/baz')
+    config.add_route('matched', '/matched/{mymatch:\d+}')
 
     config.add_view(echo, route_name='echo', renderer='json')
     config.add_view(echomulti, route_name='echomulti', renderer='json')
@@ -86,6 +91,7 @@ def testapp():
     config.add_view(foo, route_name='foo', renderer='json')
     config.add_view(Bar, route_name='bar', renderer='json')
     config.add_view(baz, route_name='baz', renderer='json')
+    config.add_view(matched, route_name='matched', renderer='json')
 
     app = config.make_wsgi_app()
 
@@ -143,3 +149,7 @@ def test_use_args_decorator_class(testapp):
 
 def test_user_kwargs_decorator(testapp):
     assert testapp.post('/baz', {'myvalue': 42}).json == {'myvalue': 42}
+
+def test_parse_matchdict(testapp):
+    res = testapp.get('/matched/1')
+    assert res.json == {'mymatch': 1}

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -39,6 +39,12 @@ logger = logging.getLogger(__name__)
 class PyramidParser(core.Parser):
     """Pyramid request argument parser."""
 
+    __location_map__ = {
+        'matchdict': 'parse_matchdict'
+    }
+
+    __location_map__.update(core.Parser.__location_map__)
+
     def parse_querystring(self, req, name, arg):
         """Pull a querystring value from the request."""
         return core.get_value(req.GET, name, arg.multiple)
@@ -68,6 +74,9 @@ class PyramidParser(core.Parser):
         """Pull a file from the request."""
         files = ((k, v) for k, v in req.POST.items() if hasattr(v, 'file'))
         return core.get_value(MultiDict(files), name, arg.multiple)
+
+    def parse_matchdict(self, req, name, arg):
+        return core.get_value(req.matchdict, name, arg.multiple)
 
     def handle_error(self, error):
         """Handles errors during parsing. Aborts the current HTTP request and

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -39,11 +39,9 @@ logger = logging.getLogger(__name__)
 class PyramidParser(core.Parser):
     """Pyramid request argument parser."""
 
-    __location_map__ = {
-        'matchdict': 'parse_matchdict'
-    }
-
-    __location_map__.update(core.Parser.__location_map__)
+    __location_map__ = dict(
+        matchdict='parse_matchdict',
+        **core.Parser.__location_map__)
 
     def parse_querystring(self, req, name, arg):
         """Pull a querystring value from the request."""


### PR DESCRIPTION
The Pyramid request matchdict contains parsed patterns from the url. Adding this functionality does a few useful things:
1. Type coercion.
2. Advanced validation.
3. Clearly marking a view as expecting a route with a particular matchdict value.

I don't love how I've done this:

``` #!python
__location_map__ = {
     'matchdict': 'parse_matchdict'
}
 __location_map__.update(core.Parser.__location_map__)
```

However not sure what else to do that would also have that level of clarity.
