### PR TITLE
Specify Mock version in dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ invoke
 # Testing
 pytest
 tox>=1.5.0
-mock
+mock==1.0.1
 webtest
 
 # Distribution


### PR DESCRIPTION
The latest version of Mock (1.3.0) in PyPI breaks some existing test cases.  Specifying version 1.0.1 to keep things working.
