### PR TITLE
No null type conversion

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -120,8 +120,8 @@ class TestArg:
         assert (arg.validated('foo', '12345678123456781234567812345678') ==
                 UUID('12345678-1234-5678-1234-567812345678'))
         with pytest.raises(ValidationError) as excinfo:
-            arg.validated('foo', None)
-        assert 'Expected type "UUID" for foo, got "null"' in str(excinfo)
+            arg.validated('foo', '123xyz')   # An invalid UUID
+        assert 'Expected type "UUID" for foo, got "string"' in str(excinfo)
 
     def test_custom_error(self):
         arg = Arg(type_=int, error='not an int!')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -115,6 +115,10 @@ class TestArg:
         arg = Arg(type_=long_type)
         assert arg.validated('foo', 42) == 42
 
+    def test_validated_string_conversion_null(self):
+        arg = Arg(type_=str)
+        assert arg.validated('foo', None) is None
+
     def test_validated_unknown_type(self):
         arg = Arg(type_=UUID)
         assert (arg.validated('foo', '12345678123456781234567812345678') ==

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -159,10 +159,27 @@ __non_nullable_types__ = set([list, tuple, set, dict, bool])
 class Arg(object):
     """A request argument.
 
+    When a value for an Arg is found in the request, it is processed by the ``validated``
+    method, which performs type conversion and any validation functions on this
+    Arg object.
+
+    The validation is performed as follows:
+
+    1. Any ``use`` functions are run to transform the value prior to type conversion.
+    2. If the value is not ``None`` then type conversion will take place, transforming the
+       value using the `type\_` parameter
+    3. Any validation functions are run. If a function returns ``False`` or raises a
+       :exc:`ValidationError` then validation for this Arg will stop and an error will
+       be raised.
+
+    In the case of a nested Arg dictionary, the validation functions are run before
+    the nested arguments are processed.
+
     :param type\_: Value type or nested `Arg` dictionary. If the former,
         the parsed value will be coerced this type. If the latter, the parsed
         value will be validated and converted according to the nested `Arg` dict.
-        If ``None``, no type conversion will be performed.
+        If the parsed value, or the `type\_` parameter is  ``None``, no type conversion
+        will be performed.
     :param default: Default value for the argument. Used if the value is not found
         on the request. May be a callable.
     :param required: If truthy, the :meth:`Parser.handle_error`

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -233,10 +233,11 @@ class Arg(object):
         if ret is None and self.type in __non_nullable_types__:
             raise ValidationError(self.error or msg, arg_name=name)
 
-        try:
-            ret = self.type(ret)
-        except (ValueError, TypeError):
-            raise ValidationError(self.error or msg, arg_name=name)
+        if ret is not None:
+            try:
+                ret = self.type(ret)
+            except (ValueError, TypeError):
+                raise ValidationError(self.error or msg, arg_name=name)
 
         # Then call validation functions
         for validator in self.validators:


### PR DESCRIPTION
Issue #54 

Don't call the type conversion function if the parsed value is None.
I've also summarised the order that argument validation takes place in the Arg class docstring.
