### PR TITLE
Option to treat null as missing 

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -411,6 +411,26 @@ def test_value_error_raised_if_invalid_location(web_request):
         p.parse_arg('foo', arg, web_request, locations=('invalidlocation', 'headers'))
     assert 'Invalid locations arguments: {0}'.format(['invalidlocation']) in str(excinfo)
 
+def test_none_as_missing_sets_default(parser, web_request):
+    web_request.json = {"name": None}
+    args = {"name": Arg(none_as_missing=True, default="Bob")}
+    result = parser.parse(args, web_request, locations=('json',))
+    assert result["name"] == "Bob"
+
+def test_none_as_missing_and_allow_missing(web_request, parser):
+    web_request.json = {"name": None}
+    args = {"name": Arg(none_as_missing=True, allow_missing=True)}
+    result = parser.parse(args, web_request, locations=("json",))
+    assert "name" not in result
+
+def test_none_as_missing_and_required(web_request, parser):
+    web_request.json = {"foo": None}
+    arg = Arg(required=True, none_as_missing=True)
+    with pytest.raises(RequiredArgMissingError) as excinfo:
+        parser.parse_arg('foo', arg, web_request)
+    assert 'Required parameter "foo" not found.' in str(excinfo)
+
+
 @mock.patch('webargs.core.Parser.parse_json')
 def test_conversion(parse_json, web_request):
     parse_json.return_value = 42

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -191,7 +191,7 @@ class Arg(object):
     """
     def __init__(self, type_=None, default=None, required=False,
                  validate=None, use=None, multiple=False, error=None,
-                 allow_missing=False, location=None, dest=None, **metadata):
+                 allow_missing=False, location=None, dest=None, none_as_missing=False, **metadata):
         if isinstance(type_, dict):
             self.type = type(type_)  # type will always be a dict
             self._nested_args = type_
@@ -212,6 +212,7 @@ class Arg(object):
         if required and allow_missing:
             raise ValueError('"required" and "allow_missing" cannot both be True.')
         self.allow_missing = allow_missing
+        self.none_as_missing = none_as_missing
         self.location = location
         self.dest = dest
         self.metadata = metadata
@@ -367,6 +368,8 @@ class Parser(object):
 
         for location in locations_to_check:
             value = self._get_value(name, argobj, req=req, location=location)
+            if argobj.none_as_missing and value is None:
+                value = Missing
             if argobj.multiple and not (isinstance(value, list) and len(value)):
                 continue
             # Found the value; validate and return it

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -179,6 +179,8 @@ class Arg(object):
     :param str error: Custom error message to use if validation fails.
     :param bool allow_missing: If the argument is not found on the request,
         don't include it in the parsed arguments dictionary.
+    :param bool none_as_missing: Treat a `None` value as if it were missing when parsing
+        this argument.
     :param str location: Where to pull the value off the request, e.g. ``'json'``.
     :param str dest: Name of the key to be added to the parsed output dictionary.
         If `None`, the key in the input argument dictionary is used.

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -193,7 +193,8 @@ class Arg(object):
     """
     def __init__(self, type_=None, default=None, required=False,
                  validate=None, use=None, multiple=False, error=None,
-                 allow_missing=False, location=None, dest=None, none_as_missing=False, **metadata):
+                 allow_missing=False, location=None, dest=None,
+                 none_as_missing=False, **metadata):
         if isinstance(type_, dict):
             self.type = type(type_)  # type will always be a dict
             self._nested_args = type_


### PR DESCRIPTION
In some situations it may be useful to treat null values in your JSON as equivalent to a missing value.

This adds a `none_as_missing` parameter to the `Arg` constructor, which when set to True will cause the `Parser.parse_arg` function to replace a `None` value with `Missing`.

This addresses the same issue as pull request #53 but shouldn't impact existing code.

A hypothetical alternative could be implemented with the `use` functions; however this currently couldn't work without shifting around some of the validation code.

``` python
def none_as_missing(value):
    return webargs.core.Missing if value is None else value

args = {
    "name": Arg(required=True, type=str, use=none_as_missing, validate=not_empty)
}
```
