### PR TITLE
Fix typo "message" to "messages"

### DIFF
--- a/docs/framework_support.rst
+++ b/docs/framework_support.rst
@@ -43,7 +43,7 @@ Here is an example error handler that returns validation messages to the client 
         # webargs attaches additional metadata to the `data` attribute
         data = getattr(err, 'data')
         if data:
-            err_message = data['message']
+            err_message = data['messages']
         else:
             err_message = 'Invalid request'
         return jsonify({


### PR DESCRIPTION
In the documentation for flask framework support, "message" key is expected
from "data" variable. It turns out, however, "data" contains a plural form
"messages" as the key.
For the purpose of this PR, code base is honored over the documentation.
