### PR TITLE
Delimited lists

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -543,17 +543,41 @@ def test_use_kwargs_with_arg_missing(web_request, parser):
 
 def test_delimited_list_default_delimiter(web_request, parser):
     web_request.json = {'ids': '1,2,3'}
-    args = {'ids': fields.DelimitedList(fields.Int())}
+    schema_cls = argmap2schema({'ids': fields.DelimitedList(fields.Int())})
+    schema = schema_cls()
 
-    result = parser.parse(args, web_request)
-    assert result['ids'] == [1, 2, 3]
+    parsed = parser.parse(schema, web_request)
+    assert parsed['ids'] == [1, 2, 3]
+
+    dumped = schema.dump(parsed).data
+    assert dumped['ids'] == [1, 2, 3]
+
+def test_delimited_list_dump_string(web_request, parser):
+    web_request.json = {'ids': '1,2,3'}
+    schema_cls = argmap2schema({'ids': fields.DelimitedList(fields.Int(), dump_string=True)})
+    schema = schema_cls()
+
+    parsed = parser.parse(schema, web_request)
+    assert parsed['ids'] == [1, 2, 3]
+
+    dumped = schema.dump(parsed).data
+    assert dumped['ids'] == '1,2,3'
 
 def test_delimited_list_custom_delimiter(web_request, parser):
     web_request.json = {'ids': '1|2|3'}
-    args = {'ids': fields.DelimitedList(fields.Int(), delimiter='|')}
+    schema_cls = argmap2schema({'ids': fields.DelimitedList(fields.Int(), delimiter='|')})
+    schema = schema_cls()
 
-    result = parser.parse(args, web_request)
-    assert result['ids'] == [1, 2, 3]
+    parsed = parser.parse(schema, web_request)
+    assert parsed['ids'] == [1, 2, 3]
+
+def test_delimited_list_load_list(web_request, parser):
+    web_request.json = {'ids': [1, 2, 3]}
+    schema_cls = argmap2schema({'ids': fields.DelimitedList(fields.Int())})
+    schema = schema_cls()
+
+    parsed = parser.parse(schema, web_request)
+    assert parsed['ids'] == [1, 2, 3]
 
 def test_missing_list_argument_not_in_parsed_result(web_request, parser):
     # arg missing in request

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,12 +16,7 @@ from webargs import (
     missing,
     ValidationError,
 )
-from webargs.core import (
-    Parser,
-    get_value,
-    is_multiple,
-    argmap2schema,
-)
+from webargs.core import Parser, get_value, argmap2schema
 
 
 class MockRequestParser(Parser):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,10 +28,10 @@ class MockRequestParser(Parser):
     """A minimal parser implementation that parses mock requests."""
 
     def parse_json(self, web_request, name, arg):
-        return get_value(web_request.json, name, is_multiple(arg))
+        return get_value(web_request.json, name, arg)
 
     def parse_cookies(self, web_request, name, arg):
-        return get_value(web_request.cookies, name, is_multiple(arg))
+        return get_value(web_request.cookies, name, arg)
 
 
 @pytest.fixture

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -546,6 +546,20 @@ def test_use_kwargs_with_arg_missing(web_request, parser):
         return {'username': username, 'password': password}
     assert viewfunc() == {'username': 'foo', 'password': missing}
 
+def test_delimited_list_default_delimiter(web_request, parser):
+    web_request.json = {'ids': '1,2,3'}
+    args = {'ids': fields.DelimitedList(fields.Int())}
+
+    result = parser.parse(args, web_request)
+    assert result['ids'] == [1, 2, 3]
+
+def test_delimited_list_custom_delimiter(web_request, parser):
+    web_request.json = {'ids': '1|2|3'}
+    args = {'ids': fields.DelimitedList(fields.Int(), delimiter='|')}
+
+    result = parser.parse(args, web_request)
+    assert result['ids'] == [1, 2, 3]
+
 def test_missing_list_argument_not_in_parsed_result(web_request, parser):
     # arg missing in request
     web_request.json = {}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -552,9 +552,9 @@ def test_delimited_list_default_delimiter(web_request, parser):
     dumped = schema.dump(parsed).data
     assert dumped['ids'] == [1, 2, 3]
 
-def test_delimited_list_dump_string(web_request, parser):
+def test_delimited_list_as_string(web_request, parser):
     web_request.json = {'ids': '1,2,3'}
-    schema_cls = argmap2schema({'ids': fields.DelimitedList(fields.Int(), dump_string=True)})
+    schema_cls = argmap2schema({'ids': fields.DelimitedList(fields.Int(), as_string=True)})
     schema = schema_cls()
 
     parsed = parser.parse(schema, web_request)

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -390,6 +390,12 @@ def test_parse_multiple(context, testapp):
         assert args['name'] == ['steve', 'Loria']
         assert args['nums'] == [4, 2]
 
+def test_parse_multiple_delimited(testapp):
+    args = {'values': fields.DelimitedList(fields.Int())}
+    with testapp.test_request_context('/?values=1,2,3'):
+        res = parser.parse(args)
+        assert res['values'] == [1, 2, 3]
+
 @mock.patch('webargs.flaskparser.abort')
 def test_multiple_required_arg(mock_abort, testapp):
     multargs = {'name': fields.List(fields.Field(), required=True)}

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -67,7 +67,7 @@ def argmap2schema(argmap, instance=False, **kwargs):
 
 def is_multiple(field):
     """Return whether or not `field` handles repeated/multi-value arguments."""
-    return isinstance(field, ma.fields.List)
+    return isinstance(field, ma.fields.List) and not hasattr(field, 'delimiter')
 
 def get_value(d, name, field):
     """Get a value from a dictionary. Handles ``MultiDict`` types when

--- a/webargs/djangoparser.py
+++ b/webargs/djangoparser.py
@@ -63,7 +63,7 @@ class DjangoParser(core.Parser):
 
     def parse_files(self, req, name, field):
         """Pull a file from the request."""
-        return core.get_value(req.FILES, name, core.is_multiple(field))
+        return core.get_value(req.FILES, name, field)
 
     def get_request_from_view_args(self, args, kwargs):
         # The first argument is either `self` or `request`

--- a/webargs/fields.py
+++ b/webargs/fields.py
@@ -43,19 +43,19 @@ class DelimitedList(ma.fields.List):
 
     :param Field cls_or_instance: A field class or instance.
     :param str delimiter: Delimiter between values.
-    :param bool dump_string: Dump values to string.
+    :param bool as_string: Dump values to string.
     """
 
     delimiter = ','
 
-    def __init__(self, cls_or_instance, delimiter=None, dump_string=False, **kwargs):
+    def __init__(self, cls_or_instance, delimiter=None, as_string=False, **kwargs):
         self.delimiter = delimiter or self.delimiter
-        self.dump_string = dump_string
+        self.as_string = as_string
         super(DelimitedList, self).__init__(cls_or_instance, **kwargs)
 
     def _serialize(self, value, attr, obj):
         ret = super(DelimitedList, self)._serialize(value, attr, obj)
-        if self.dump_string:
+        if self.as_string:
             return self.delimiter.join(format(each) for each in value)
         return ret
 

--- a/webargs/fields.py
+++ b/webargs/fields.py
@@ -41,14 +41,21 @@ class DelimitedList(ma.fields.List):
 
     delimiter = ','
 
-    def __init__(self, cls_or_instance, delimiter=None, **kwargs):
+    def __init__(self, cls_or_instance, delimiter=None, dump_string=False, **kwargs):
         self.delimiter = delimiter or self.delimiter
+        self.dump_string = dump_string
         super(DelimitedList, self).__init__(cls_or_instance, **kwargs)
 
     def _serialize(self, value, attr, obj):
         ret = super(DelimitedList, self)._serialize(value, attr, obj)
-        return self.delimiter.join(ret)
+        if self.dump_string:
+            return self.delimiter.join(format(each) for each in value)
+        return ret
 
     def _deserialize(self, value, attr, data):
-        ret = value.split(self.delimiter)
+        ret = (
+            value
+            if ma.utils.is_iterable_but_not_string(value)
+            else value.split(self.delimiter)
+        )
         return super(DelimitedList, self)._deserialize(ret, attr, data)

--- a/webargs/fields.py
+++ b/webargs/fields.py
@@ -38,6 +38,13 @@ class Nested(ma.fields.Nested):
         super(Nested, self).__init__(nested, *args, **kwargs)
 
 class DelimitedList(ma.fields.List):
+    """Same as `marshmallow.fields.List`, except can load from either a list or
+    a delimited string (e.g. "foo,bar,baz").
+
+    :param Field cls_or_instance: A field class or instance.
+    :param str delimiter: Delimiter between values.
+    :param bool dump_string: Dump values to string.
+    """
 
     delimiter = ','
 

--- a/webargs/fields.py
+++ b/webargs/fields.py
@@ -36,3 +36,19 @@ class Nested(ma.fields.Nested):
         if isinstance(nested, dict):
             nested = argmap2schema(nested)
         super(Nested, self).__init__(nested, *args, **kwargs)
+
+class DelimitedList(ma.fields.List):
+
+    delimiter = ','
+
+    def __init__(self, cls_or_instance, delimiter=None, **kwargs):
+        self.delimiter = delimiter or self.delimiter
+        super(DelimitedList, self).__init__(cls_or_instance, **kwargs)
+
+    def _serialize(self, value, attr, obj):
+        ret = super(DelimitedList, self)._serialize(value, attr, obj)
+        return self.delimiter.join(ret)
+
+    def _deserialize(self, value, attr, data):
+        ret = value.split(self.delimiter)
+        return super(DelimitedList, self)._deserialize(ret, attr, data)


### PR DESCRIPTION
Proposed implementation of #66. Interface:

``` python
args = {'values': fields.DelimitedList(fields.Int())}
args = {'values': fields.DelimitedList(fields.Int(), delimiter='|')}
...
```
