### PR TITLE
use_args decorators now support callables in the first argument.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -278,7 +278,10 @@ def test_full_input_validation_with_multiple_validators(web_request, parser):
 def test_required_with_custom_error(web_request):
     web_request.json = {}
     parser = MockRequestParser()
-    args = {'foo': fields.Str(required='We need foo')}
+    args = {'foo': fields.Str(
+        required=True,
+        error_messages={'required': 'We need foo'})
+    }
     with pytest.raises(ValidationError) as excinfo:
         # Test that `validate` receives dictionary of args
         parser.parse(args, web_request, locations=('json', ))

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -80,7 +80,6 @@ class AsyncParser(core.Parser):
 
                 if not req_obj:
                     req_obj = self.get_request_from_view_args(func, args, kwargs)
-                schema = constructor(req_obj)
                 parsed_args = yield from self.parse(schema or argmap(request),
                                                     req=req_obj, locations=locations,
                                                     validate=validate, force_all=force_all)

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -62,6 +62,8 @@ class AsyncParser(core.Parser):
         locations = locations or self.locations
         if isinstance(argmap, ma.Schema):
             schema = argmap
+        elif callable(argmap):
+            schema = None
         else:
             schema = core.argmap2schema(argmap)()
         request_obj = req
@@ -78,8 +80,10 @@ class AsyncParser(core.Parser):
 
                 if not req_obj:
                     req_obj = self.get_request_from_view_args(func, args, kwargs)
-                parsed_args = yield from self.parse(schema, req=req_obj, locations=locations,
-                                         validate=validate, force_all=force_all)
+                schema = constructor(req_obj)
+                parsed_args = yield from self.parse(schema or argmap(request),
+                                                    req=req_obj, locations=locations,
+                                                    validate=validate, force_all=force_all)
                 if as_kwargs:
                     kwargs.update(parsed_args)
                     return func(*args, **kwargs)

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -80,7 +80,7 @@ class AsyncParser(core.Parser):
 
                 if not req_obj:
                     req_obj = self.get_request_from_view_args(func, args, kwargs)
-                parsed_args = yield from self.parse(schema or argmap(request),
+                parsed_args = yield from self.parse(schema or argmap(req_obj),
                                                     req=req_obj, locations=locations,
                                                     validate=validate, force_all=force_all)
                 if as_kwargs:


### PR DESCRIPTION
Any callable supplied should take the request as an argument and return a marshmallow schema instance.
