### PR TITLE
Closes #81: Added bulk-type arguments support

### DIFF
--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -65,13 +65,12 @@ class AIOHTTPParser(AsyncParser):
     @asyncio.coroutine
     def parse_json(self, req, name, field):
         """Pull a json value from the request."""
-        if req.has_body and is_json_request(req):
-            json_data = self._cache.get('json')
-            if json_data is None:
-                self._cache['json'] = yield from req.json()
-            return core.get_value(self._cache['json'], name, field)
-        else:
+        if not (req.has_body and is_json_request(req)):
             return core.missing
+        json_data = self._cache.get('json')
+        if json_data is None:
+            self._cache['json'] = json_data = yield from req.json()
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_headers(self, req, name, field):
         """Pull a value from the header data."""

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -36,16 +36,15 @@ class BottleParser(core.Parser):
 
     def parse_json(self, req, name, field):
         """Pull a json value from the request."""
-        json_body = self._cache.get('json')
-        if json_body is None:
+        json_data = self._cache.get('json')
+        if json_data is None:
             try:
-                self._cache['json'] = json_body = req.json
+                self._cache['json'] = json_data = req.json
             except (AttributeError, ValueError):
                 return core.missing
-        if json_body is not None:
-            return core.get_value(req.json, name, field)
-        else:
-            return core.missing
+            if json_data is None:
+                return core.missing
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_headers(self, req, name, field):
         """Pull a value from the header data."""

--- a/webargs/djangoparser.py
+++ b/webargs/djangoparser.py
@@ -45,11 +45,10 @@ class DjangoParser(core.Parser):
     def parse_json(self, req, name, field):
         """Pull a json value from the request body."""
         try:
-            reqdata = json.loads(req.body.decode('utf-8'))
-            return core.get_value(reqdata, name, field)
+            json_data = json.loads(req.body.decode('utf-8'))
         except (AttributeError, ValueError):
-            pass
-        return core.missing
+            return core.missing
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_cookies(self, req, name, field):
         """Pull the value from the cookiejar."""

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -53,10 +53,10 @@ class FalconParser(core.Parser):
 
     def parse_json(self, req, name, field):
         """Pull a JSON body value from the request."""
-        json_body = self._cache.get('json')
-        if json_body is None:
-            self._cache['json'] = json_body = parse_json_body(req)
-        return core.get_value(json_body, name, field)
+        json_data = self._cache.get('json_data')
+        if json_data is None:
+            self._cache['json_data'] = json_data = parse_json_body(req)
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_headers(self, req, name, field):
         """Pull a header value from the request."""

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -62,10 +62,9 @@ class FlaskParser(core.Parser):
         force = is_json_request(req)
         # Fail silently so that the webargs parser can handle the error
         json_data = req.get_json(force=force, silent=True)
-        if json_data:
-            return core.get_value(json_data, name, field)
-        else:
+        if json_data is None:
             return core.missing
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):
         """Pull a querystring value from the request."""

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -56,8 +56,7 @@ class PyramidParser(core.Parser):
             json_data = req.json_body
         except ValueError:
             return core.missing
-
-        return core.get_value(json_data, name, field)
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_cookies(self, req, name, field):
         """Pull the value from the cookiejar."""

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -14,10 +14,10 @@ Example: ::
             response = {'message': 'Hello {}'.format(args['name'])}
             self.write(response)
 """
-from marshmallow.compat import basestring
 import tornado.web
 from tornado.escape import _unicode
 
+from marshmallow.compat import basestring
 from webargs import core
 
 
@@ -77,10 +77,12 @@ class TornadoParser(core.Parser):
 
     def parse_json(self, req, name, field):
         """Pull a json value from the request."""
-        json_body = self._cache.get('json')
-        if json_body is None:
-            self._cache['json'] = parse_json_body(req)
-        return get_value(self._cache['json'], name, field)
+        json_data = self._cache.get('json')
+        if json_data is None:
+            self._cache['json'] = json_data = parse_json_body(req)
+            if json_data is None:
+                return core.missing
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):
         """Pull a querystring value from the request."""

--- a/webargs/webapp2parser.py
+++ b/webargs/webapp2parser.py
@@ -40,9 +40,9 @@ class Webapp2Parser(core.Parser):
         """Pull a json value from the request."""
         try:
             json_data = webapp2_extras.json.decode(req.body)
-            return core.get_value(json_data, name, field)
         except ValueError:
             return core.missing
+        return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):
         """Pull a querystring value from the request."""


### PR DESCRIPTION
Read more details in #81.

Here is a brief example:

``` python
@use_args(MySchema(many=True), locations=('json', ))
def get(args):
```

Such function will expect to receive a JSON array of `MySchema` items.
