### PR TITLE
[Docs] Rename bad_request -> unprocessable_entity

### DIFF
--- a/docs/framework_support.rst
+++ b/docs/framework_support.rst
@@ -39,7 +39,7 @@ Here is an example error handler that returns validation messages to the client 
     from flask import jsonify
 
     @app.errorhandler(422)
-    def handle_bad_request(err):
+    def handle_unprocessable_entity(err):
         # webargs attaches additional metadata to the `data` attribute
         data = getattr(err, 'data')
         if data:


### PR DESCRIPTION
Minor edit to the docs. `unprocessable_entity` seems more appropriate for a 422 status.
