### PR TITLE
original function in decorator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Contributors (chronological)
 * Brett Higgins <https://github.com/brettdh>
 * Vlad Frolov <https://github.com/frol>
 * Tuukka Mustonen <https://github.com/tuukkamustonen>
+* Francois-Xavier Darveau <https://github.com/EFF> 

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -103,6 +103,7 @@ class AsyncParser(core.Parser):
                     # Add parsed_args after other positional arguments
                     new_args = args + (parsed_args, )
                     return func(*new_args, **kwargs)
+            wrapper.__wrapped__ = func
             return wrapper
         return decorator
 

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -436,6 +436,7 @@ class Parser(object):
                     # Add parsed_args after other positional arguments
                     new_args = args + (parsed_args, )
                     return func(*new_args, **kwargs)
+            wrapper.__wrapped__ = func
             return wrapper
         return decorator
 

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -121,6 +121,7 @@ class PyramidParser(core.Parser):
                     return func(obj, *args, **kwargs)
                 else:
                     return func(obj, parsed_args, *args, **kwargs)
+            wrapper.__wrapped__ = func
             return wrapper
         return decorator
 


### PR DESCRIPTION
Done:
===
Added a reference to the original function in the use_args decorator or unit testing purpose. Now, with these little changes, a user can import it's decorated function and still can unit test it's original function.

Should I had a small unit testing section in the docs ?

Note : 
---
I could have added the [Venusian](http://docs.pylonsproject.org/projects/venusian/en/latest/) library that is exactly for that purpose but it would have add a dependency to the project and it would have alter the decorators' behaviour a little. Tell me what you prefer.