### PR TITLE
allow use_args/use_kwargs decorators with async def coroutines

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ universal = 1
 [flake8]
 ignore = E127,E128,E265,E302,N803,N804,N806,E731,E402,E266,E305
 max-line-length = 100
-exclude = .git,.ropeproject,.tox,docs,.git,setup.py,tests/compat.py,build,.direnv
+exclude = .git,.ropeproject,.tox,docs,.git,setup.py,tests/compat.py,build,.direnv,webargs/async_decorators.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,4 +4,4 @@ universal = 1
 [flake8]
 ignore = E127,E128,E265,E302,N803,N804,N806,E731,E402,E266,E305
 max-line-length = 100
-exclude = .git,.ropeproject,.tox,docs,.git,setup.py,tests/compat.py,build,.direnv,webargs/async_decorators.py
+exclude = .git,.ropeproject,.tox,docs,.git,setup.py,tests/compat.py,build,.direnv

--- a/tasks.py
+++ b/tasks.py
@@ -27,15 +27,22 @@ def test(ctx, coverage=False, browse=False):
 def flake(ctx):
     """Run flake8 on codebase."""
     cmd = 'flake8 .'
+    excludes = []
     if sys.version_info < (3, 4, 1):
         excludes = [
             os.path.join('tests', 'apps', 'aiohttp_app.py'),
             os.path.join('tests', 'test_aiohttparser.py'),
             os.path.join('webargs', 'async.py'),
+            os.path.join('webargs', 'async_decorators34.py'),
             os.path.join('webargs', 'aiohttpparser.py'),
             os.path.join('examples', 'annotations_example.py'),
             'build',
         ]
+    if sys.version_info < (3, 5, 0):
+        excludes += [
+            os.path.join('webargs', 'async_decorators.py'),
+        ]
+    if excludes:
         cmd += ' --exclude={0}'.format(','.join(excludes))
     ctx.run(cmd, echo=True)
 

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 """Asynchronous request parser. Compatible with Python>=3.4."""
 import asyncio
-import collections
-import inspect
-import functools
 import sys
+import inspect
 
 import marshmallow as ma
 from marshmallow.compat import iteritems
@@ -12,13 +10,12 @@ from marshmallow.utils import missing
 
 from webargs import core
 
-PY_35 = sys.version_info >= (3, 5)
+PY_34 = sys.version_info < (3, 5)
 
-
-def iscoroutinefunction(func):
-    if PY_35:
-        return inspect.iscoroutinefunction(func)
-    return False
+if PY_34:
+    from webargs.async_decorators34 import _use_args
+else:
+    from webargs.async_decorators import _use_args
 
 class AsyncParser(core.Parser):
     """Asynchronous variant of `webargs.core.Parser`, where parsing methods may be
@@ -80,66 +77,7 @@ class AsyncParser(core.Parser):
             core.fill_in_missing_args(ret, argmap)
         return ret
 
-    def use_args(self, argmap, req=None, locations=None, as_kwargs=False, validate=None):
-        """Decorator that injects parsed arguments into a view function or method.
-
-        Receives the same arguments as `webargs.core.Parser.use_args`.
-        """
-        locations = locations or self.locations
-        request_obj = req
-        # Optimization: If argmap is passed as a dictionary, we only need
-        # to generate a Schema once
-        if isinstance(argmap, collections.Mapping):
-            argmap = core.argmap2schema(argmap)()
-
-        def decorator(func):
-            req_ = request_obj
-
-            if iscoroutinefunction(func):
-                @functools.wraps(func)
-                async def wrapper(*args, **kwargs):
-                    req_obj = req_
-
-                    # if as_kwargs is passed, must include all args
-                    force_all = as_kwargs
-
-                    if not req_obj:
-                        req_obj = self.get_request_from_view_args(func, args, kwargs)
-                    # NOTE: At this point, argmap may be a Schema, callable, or dict
-                    parsed_args = await self.parse(argmap,
-                                                        req=req_obj, locations=locations,
-                                                        validate=validate, force_all=force_all)
-                    if as_kwargs:
-                        kwargs.update(parsed_args)
-                        return await func(*args, **kwargs)
-                    else:
-                        # Add parsed_args after other positional arguments
-                        new_args = args + (parsed_args, )
-                        return await func(*new_args, **kwargs)
-            else:
-                @functools.wraps(func)
-                def wrapper(*args, **kwargs):
-                    req_obj = req_
-
-                    # if as_kwargs is passed, must include all args
-                    force_all = as_kwargs
-
-                    if not req_obj:
-                        req_obj = self.get_request_from_view_args(func, args, kwargs)
-                    # NOTE: At this point, argmap may be a Schema, callable, or dict
-                    parsed_args = yield from self.parse(argmap,
-                                                        req=req_obj, locations=locations,
-                                                        validate=validate, force_all=force_all)
-                    if as_kwargs:
-                        kwargs.update(parsed_args)
-                        return func(*args, **kwargs)
-                    else:
-                        # Add parsed_args after other positional arguments
-                        new_args = args + (parsed_args, )
-                        return func(*new_args, **kwargs)
-            wrapper.__wrapped__ = func
-            return wrapper
-        return decorator
+    use_args = _use_args
 
     def use_kwargs(self, *args, **kwargs):
         """Decorator that injects parsed arguments into a view function or method.

--- a/webargs/async_decorators.py
+++ b/webargs/async_decorators.py
@@ -1,0 +1,67 @@
+import inspect
+import collections
+import functools
+
+from webargs import core
+
+
+def _use_args(self, argmap, req=None, locations=None, as_kwargs=False, validate=None):
+    """Decorator that injects parsed arguments into a view function or method.
+
+    Receives the same arguments as `webargs.core.Parser.use_args`.
+    """
+    locations = locations or self.locations
+    request_obj = req
+    # Optimization: If argmap is passed as a dictionary, we only need
+    # to generate a Schema once
+    if isinstance(argmap, collections.Mapping):
+        argmap = core.argmap2schema(argmap)()
+
+    def decorator(func):
+        req_ = request_obj
+
+        if inspect.iscoroutinefunction(func):
+            @functools.wraps(func)
+            async def wrapper(*args, **kwargs):
+                req_obj = req_
+
+                # if as_kwargs is passed, must include all args
+                force_all = as_kwargs
+
+                if not req_obj:
+                    req_obj = self.get_request_from_view_args(func, args, kwargs)
+                # NOTE: At this point, argmap may be a Schema, callable, or dict
+                parsed_args = await self.parse(argmap,
+                                                    req=req_obj, locations=locations,
+                                                    validate=validate, force_all=force_all)
+                if as_kwargs:
+                    kwargs.update(parsed_args)
+                    return await func(*args, **kwargs)
+                else:
+                    # Add parsed_args after other positional arguments
+                    new_args = args + (parsed_args, )
+                    return await func(*new_args, **kwargs)
+        else:
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                req_obj = req_
+
+                # if as_kwargs is passed, must include all args
+                force_all = as_kwargs
+
+                if not req_obj:
+                    req_obj = self.get_request_from_view_args(func, args, kwargs)
+                # NOTE: At this point, argmap may be a Schema, callable, or dict
+                parsed_args = yield from self.parse(argmap,
+                                                    req=req_obj, locations=locations,
+                                                    validate=validate, force_all=force_all)
+                if as_kwargs:
+                    kwargs.update(parsed_args)
+                    return func(*args, **kwargs)
+                else:
+                    # Add parsed_args after other positional arguments
+                    new_args = args + (parsed_args, )
+                    return func(*new_args, **kwargs)
+        wrapper.__wrapped__ = func
+        return wrapper
+    return decorator

--- a/webargs/async_decorators34.py
+++ b/webargs/async_decorators34.py
@@ -1,0 +1,44 @@
+import collections
+import functools
+
+from webargs import core
+
+
+def _use_args(self, argmap, req=None, locations=None, as_kwargs=False, validate=None):
+    """Decorator that injects parsed arguments into a view function or method.
+
+    Receives the same arguments as `webargs.core.Parser.use_args`.
+    """
+    locations = locations or self.locations
+    request_obj = req
+    # Optimization: If argmap is passed as a dictionary, we only need
+    # to generate a Schema once
+    if isinstance(argmap, collections.Mapping):
+        argmap = core.argmap2schema(argmap)()
+
+    def decorator(func):
+        req_ = request_obj
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            req_obj = req_
+
+            # if as_kwargs is passed, must include all args
+            force_all = as_kwargs
+
+            if not req_obj:
+                req_obj = self.get_request_from_view_args(func, args, kwargs)
+            # NOTE: At this point, argmap may be a Schema, callable, or dict
+            parsed_args = yield from self.parse(argmap,
+                                                req=req_obj, locations=locations,
+                                                validate=validate, force_all=force_all)
+            if as_kwargs:
+                kwargs.update(parsed_args)
+                return func(*args, **kwargs)
+            else:
+                # Add parsed_args after other positional arguments
+                new_args = args + (parsed_args, )
+                return func(*new_args, **kwargs)
+        wrapper.__wrapped__ = func
+        return wrapper
+    return decorator


### PR DESCRIPTION
make the following work

``` python
@use_args({'name': fields.Str()})
async def api_test(request, args):
      ....
```

I am not certain this is the best way to achieve it,  but testing it  on my aiohttp application shows it works well.