### PR TITLE
flaskparser.abort: add data to exception even if kwargs is empty

### DIFF
--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -34,8 +34,7 @@ def abort(http_status_code, exc=None, **kwargs):
     try:
         flask.abort(http_status_code)
     except HTTPException as err:
-        if len(kwargs):
-            err.data = kwargs
+        err.data = kwargs
         err.exc = exc
         raise err
 


### PR DESCRIPTION
Any objection to this?

It doesn't break any existing test.

The idea is to avoid checking that exception has `data` attribute and get its content directly.

Currently, I need to do

```python
    # Use one kwarg
    if hasattr(error, data):
        error.data.get(my_kwarg, default_val)

    # Use all kwargs
    if hasattr(error, data):
        my_function(**error.data)
```

With this change, I would just do

```python
    # Use one kwarg
    error.data.get(my_kwarg, default_val)

    # Use all kwargs
    my_function(**error.data)
```

And if I just want to check that args were passed, I'll do

```python
    if error.data:
```

rather than

```python
    if hasattr(error, data):
```
