### PR TITLE
Fix pyup.io config file

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,4 +1,5 @@
+
 requirements:
   - docs/requirements.txt
   - dev-requirements.txt:
-    pin: False
+      pin: False


### PR DESCRIPTION
It looks like the `.pyup.yml` used in this repo caused the bot to parse `dev-requirements.txt` as an empty dictionary
```
{
   "dev-requirements.txt": null, 
    "pin": false
}
```
instead of a dictionary with options
```
{
    "dev-requirements.txt": {
        "pin": false
    }
}
```


This PR fixes that.

Silent errors are terrible, though. I'm currently working on a branch that allows the bot to recover from minor glitches like this and tells the user that there's something wrong with the config file.

Thanks for letting me know!