### PR TITLE
Allow Marshmallow validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pip-log.txt
 .tox
 nosetests.xml
 htmlcov
+.pytest_cache/
 
 # Translations
 *.mo
@@ -42,6 +43,9 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# VSCode 
+.vscode/
 
 README.html
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ pip-log.txt
 .tox
 nosetests.xml
 htmlcov
-.pytest_cache/
 
 # Translations
 *.mo
@@ -43,9 +42,6 @@ output/*/index.html
 
 # Sphinx
 docs/_build
-
-# VSCode 
-.vscode/
 
 README.html
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -133,7 +133,7 @@ class CommonTestCase(object):
 
     def test_parsing_headers(self, testapp):
         res = testapp.get('/echo_headers', headers={'name': 'Fred'})
-        assert res.json == {'name': 'Fred'}
+        assert set({'name': 'Fred'}) - set(res.json) == set()
 
     def test_parsing_cookies(self, testapp):
         testapp.set_cookie('name', 'Steve')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,11 +89,10 @@ def test_parse_headers_called_when_headers_is_a_location(parse_headers, web_requ
 
 @mock.patch('webargs.core.Parser.parse_cookies')
 def test_parse_cookies_called_when_cookies_is_a_location(parse_cookies, web_request):
-    field = fields.Field()
     p = Parser()
-    p.parse_arg('foo', field, web_request)
+    p.parse_arg(web_request)
     assert parse_cookies.call_count == 0
-    p.parse_arg('foo', field, web_request, locations=('cookies',))
+    p.parse_arg(web_request, locations=('cookies',))
     parse_cookies.assert_called()
 
 @mock.patch('webargs.core.Parser.parse_json')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,8 +37,12 @@ class MockRequestParser(Parser):
 def web_request():
     req = mock.Mock()
     req.query = {}
+    req.json = {}
+    req.cookies = {}
     yield req
     req.query = {}
+    req.json = {}
+    req.cookies = {}
 
 @pytest.fixture
 def parser():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -73,18 +73,16 @@ def test_parse_form_called_by_parse_arg(parse_form, web_request):
 
 @mock.patch('webargs.core.Parser.parse_json')
 def test_parse_json_not_called_when_json_not_a_location(parse_json, web_request):
-    field = fields.Field()
     p = Parser()
-    p.parse_arg('foo', field, web_request, locations=('form', 'querystring'))
+    p.parse_arg(web_request, locations=('form', 'querystring'))
     assert parse_json.call_count == 0
 
 @mock.patch('webargs.core.Parser.parse_headers')
 def test_parse_headers_called_when_headers_is_a_location(parse_headers, web_request):
-    field = fields.Field()
     p = Parser()
-    p.parse_arg('foo', field, web_request)
+    p.parse_arg(web_request)
     assert parse_headers.call_count == 0
-    p.parse_arg('foo', field, web_request, locations=('headers',))
+    p.parse_arg(web_request, locations=('headers',))
     parse_headers.assert_called()
 
 @mock.patch('webargs.core.Parser.parse_cookies')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,14 +23,14 @@ strict_kwargs = {'strict': True} if MARSHMALLOW_VERSION_INFO[0] < 3 else {}
 class MockRequestParser(Parser):
     """A minimal parser implementation that parses mock requests."""
 
-    def parse_querystring(self, req, name, field):
-        return get_value(req.query, name, field)
+    def parse_querystring(self, req):
+        return req.query
 
-    def parse_json(self, req, name, field):
-        return get_value(req.json, name, field)
+    def parse_json(self, req):
+        return req.json
 
-    def parse_cookies(self, req, name, field):
-        return get_value(req.cookies, name, field)
+    def parse_cookies(self, req):
+        return req.cookies
 
 
 @pytest.yield_fixture(scope='function')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -194,10 +194,9 @@ def test_arg_with_default_and_location(parser, web_request):
     assert parser.parse(args, web_request) == {'p': 1}
 
 def test_value_error_raised_if_parse_arg_called_with_invalid_location(web_request):
-    field = fields.Field()
     p = Parser()
     with pytest.raises(ValueError) as excinfo:
-        p.parse_arg('foo', field, web_request, locations=('invalidlocation', 'headers'))
+        p.parse_arg(web_request, locations=('invalidlocation', 'headers'))
     assert 'Invalid locations arguments: {0}'.format(['invalidlocation']) in str(excinfo)
 
 def test_value_error_raised_if_invalid_location_on_field(web_request, parser):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -265,8 +265,8 @@ def test_custom_location_handler(web_request):
     parser = Parser()
 
     @parser.location_handler('data')
-    def parse_data(req, name, arg):
-        return req.data.get(name, missing)
+    def parse_data(req):
+        return req.data
 
     result = parser.parse({'foo': fields.Int()}, web_request, locations=('data', ))
     assert result['foo'] == 42
@@ -276,8 +276,8 @@ def test_custom_location_handler_with_load_from(web_request):
     parser = Parser()
 
     @parser.location_handler('data')
-    def parse_data(req, name, arg):
-        return req.data.get(name, missing)
+    def parse_data(req,):
+        return req.data
 
     result = parser.parse({'x_foo': fields.Int(load_from='X-Foo')},
         web_request, locations=('data', ))
@@ -748,8 +748,8 @@ def test_use_args_with_custom_locations_in_parser(web_request, parser):
     parser.locations = ('custom',)
 
     @parser.location_handler('custom')
-    def parse_custom(req, name, arg):
-        return 'bar'
+    def parse_custom(req):
+        return {'foo': 'bar'}
 
     @parser.use_args(custom_args, web_request)
     def viewfunc(args):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -52,23 +52,20 @@ def parser():
 
 @mock.patch('webargs.core.Parser.parse_json')
 def test_parse_json_called_by_parse_arg(parse_json, web_request):
-    field = fields.Field()
     p = Parser()
-    p.parse_arg('foo', field, web_request)
-    parse_json.assert_called_with(web_request, 'foo', field)
+    p.parse_arg(web_request)
+    parse_json.assert_called_with(web_request)
 
 @mock.patch('webargs.core.Parser.parse_querystring')
 def test_parse_querystring_called_by_parse_arg(parse_querystring, web_request):
-    field = fields.Field()
     p = Parser()
-    p.parse_arg('foo', field, web_request)
+    p.parse_arg(web_request)
     assert parse_querystring.called_once()
 
 @mock.patch('webargs.core.Parser.parse_form')
 def test_parse_form_called_by_parse_arg(parse_form, web_request):
-    field = fields.Field()
     p = Parser()
-    p.parse_arg('foo', field, web_request)
+    p.parse_arg(web_request)
     assert parse_form.called_once()
 
 @mock.patch('webargs.core.Parser.parse_json')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -128,11 +128,10 @@ def test_arg_allow_none(parser, web_request):
 
 @mock.patch('webargs.core.Parser.parse_json')
 def test_parse_required_arg(parse_json, web_request):
-    arg = fields.Field(required=True)
-    parse_json.return_value = 42
+    parse_json.return_value = {'foo': 42}
     p = Parser()
-    result = p.parse_arg('foo', arg, web_request, locations=('json', ))
-    assert result == 42
+    result = p.parse_arg(web_request, locations=('json', ))
+    assert result == {'foo': 42}
 
 def test_parse_required_list(parser, web_request):
     web_request.json = {'bar': []}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,7 +92,7 @@ def test_parse_cookies_called_when_cookies_is_a_location(parse_cookies, web_requ
 
 @mock.patch('webargs.core.Parser.parse_json')
 def test_parse(parse_json, web_request):
-    parse_json.return_value = 42
+    parse_json.return_value = { 'username': 42, 'password': 42}
     argmap = {
         'username': fields.Field(),
         'password': fields.Field(),

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -78,8 +78,8 @@ def test_abort_called_on_validation_error(mock_abort):
 
 def test_parse_form_returns_missing_if_no_form():
     req = mock.Mock()
-    req.form.get.side_effect = AttributeError('no form')
-    assert parser.parse_form(req, 'foo', fields.Field()) is missing
+    del req.form
+    assert parser.parse_form(req) == {}
 
 def test_abort_with_message():
     with pytest.raises(HTTPException) as excinfo:

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -140,7 +140,7 @@ class TestJSONArgs(object):
     def test_it_should_get_multiple_nested_values(self):
         query = {name: [{'id': 1, 'name': 'foo'}, {'id': 2, 'name': 'bar'}]}
         request = make_json_request(query)
-        result = parser.parse_json(request)
+        result = parser.parse_json(request)[name]
         assert result == [{'id': 1, 'name': 'foo'}, {'id': 2, 'name': 'bar'}]
 
     def test_it_should_return_missing_if_not_present(self):

--- a/tests/test_webapp2parser.py
+++ b/tests/test_webapp2parser.py
@@ -86,9 +86,10 @@ def test_parsing_cookies():
 
 
 def test_parsing_headers():
-    expected = {'name': 'Fred'}
+    expected = {'Name': 'Fred'}
     request = webapp2.Request.blank('/', headers=expected)
-    assert parser.parse(hello_args, req=request, locations=('headers',)) == expected
+    assert parser.parse({'Name': fields.Str(missing='World')},
+                        req=request, locations=('headers',)) == expected
 
 
 def test_parse_files():

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -276,6 +276,7 @@ class Parser(object):
             argdict = schema.fields
             for argname, field_obj in iteritems(argdict):
                 loc = field_obj.metadata.get('location')
+                multiple = is_multiple(field_obj)
                 if loc:
                     print('getting', argname, 'from', loc)
                     locations_to_check = self._validated_locations([loc])
@@ -284,6 +285,9 @@ class Parser(object):
                                            allow_many_nested=True)
                     if value is not missing:
                         parsed[argname] = value
+                val = parsed.get(argname)
+                if multiple and val is not None and not isinstance(val, (list, tuple)):
+                    parsed[argname] = [val]
         return parsed
 
     def load(self, data, argmap):

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -251,7 +251,7 @@ class Parser(object):
         locations_to_check = self._validated_locations(locations or self.locations)
         print('parse_arg: locations', locations_to_check)
 
-        values = MultiDict()
+        values = {}
         for location in locations_to_check:
             new_values = self._get_value(req=req, location=location)
             print('parse_arg: new_values:', new_values, 'from', location)

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -80,11 +80,11 @@ class HTTPError(falcon.HTTPError):
 class FalconParser(core.Parser):
     """Falcon request argument parser."""
 
-    def parse_querystring(self, req, name, field):
+    def parse_querystring(self, req):
         """Pull a querystring value from the request."""
-        return core.get_value(req.params, name, field)
+        return req.params
 
-    def parse_form(self, req, name, field):
+    def parse_form(self, req):
         """Pull a form value from the request.
 
         .. note::
@@ -94,9 +94,9 @@ class FalconParser(core.Parser):
         form = self._cache.get('form')
         if form is None:
             self._cache['form'] = form = parse_form_body(req)
-        return core.get_value(form, name, field)
+        return form
 
-    def parse_json(self, req, name, field):
+    def parse_json(self, req):
         """Pull a JSON body value from the request.
 
         .. note::
@@ -106,19 +106,19 @@ class FalconParser(core.Parser):
         json_data = self._cache.get('json_data')
         if json_data is None:
             self._cache['json_data'] = json_data = parse_json_body(req)
-        return core.get_value(json_data, name, field, allow_many_nested=True)
+        return json_data
 
-    def parse_headers(self, req, name, field):
+    def parse_headers(self, req):
         """Pull a header value from the request."""
         # Use req.get_headers rather than req.headers for performance
-        return req.get_header(name, required=False) or core.missing
+        return req.headers
 
-    def parse_cookies(self, req, name, field):
+    def parse_cookies(self, req):
         """Pull a cookie value from the request."""
         cookies = self._cache.get('cookies')
         if cookies is None:
             self._cache['cookies'] = cookies = req.cookies
-        return core.get_value(cookies, name, field)
+        return cookies
 
     def get_request_from_view_args(self, view, args, kwargs):
         """Get request from a resource method's arguments. Assumes that
@@ -128,7 +128,7 @@ class FalconParser(core.Parser):
         assert isinstance(req, falcon.Request), 'Argument is not a falcon.Request'
         return req
 
-    def parse_files(self, req, name, field):
+    def parse_files(self, req):
         raise NotImplementedError('Parsing files not yet supported by {0}'
             .format(self.__class__.__name__))
 

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -108,7 +108,6 @@ class FlaskParser(core.Parser):
 
     def _flatten_multidict(self, multidict):
         flat = multidict.to_dict(flat=False)
-        print(flat)
         for key, value in flat.items():
             if len(value) == 1:
                 flat[key] = value[0]

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -74,12 +74,12 @@ class FlaskParser(core.Parser):
 
     def parse_querystring(self, req):
         """Pull a querystring value from the request."""
-        return req.args
+        return self._flatten_multidict(req.args)
 
     def parse_form(self, req):
         """Pull a form value from the request."""
         try:
-            return req.form
+            return self._flatten_multidict(req.form)
         except AttributeError:
             return {}
 
@@ -93,7 +93,7 @@ class FlaskParser(core.Parser):
 
     def parse_files(self, req):
         """Pull a file from the request."""
-        return req.files
+        return self._flatten_multidict(req.files)
 
     def handle_error(self, error):
         """Handles errors during parsing. Aborts the current HTTP request and
@@ -105,6 +105,14 @@ class FlaskParser(core.Parser):
     def get_default_request(self):
         """Override to use Flask's thread-local request objec by default"""
         return flask.request
+
+    def _flatten_multidict(self, multidict):
+        flat = multidict.to_dict(flat=False)
+        print(flat)
+        for key, value in flat.items():
+            if len(value) == 1:
+                flat[key] = value[0]
+        return flat
 
 parser = FlaskParser()
 use_args = parser.use_args

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -81,8 +81,7 @@ class FlaskParser(core.Parser):
         try:
             return req.form
         except AttributeError:
-            pass
-        return {}
+            return {}
 
     def parse_headers(self, req):
         """Pull a value from the header data."""

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -51,11 +51,11 @@ class FlaskParser(core.Parser):
         **core.Parser.__location_map__
     )
 
-    def parse_view_args(self, req, name, field):
+    def parse_view_args(self, req):
         """Pull a value from the request's ``view_args``."""
-        return core.get_value(req.view_args, name, field)
+        return req.view_args
 
-    def parse_json(self, req, name, field):
+    def parse_json(self, req):
         """Pull a json value from the request."""
         # Pass force in order to handle vendor media types,
         # e.g. applications/vnd.json+api
@@ -69,32 +69,32 @@ class FlaskParser(core.Parser):
             # Flask <= 0.9.x
             json_data = req.json
         if json_data is None:
-            return core.missing
-        return core.get_value(json_data, name, field, allow_many_nested=True)
+            return {}
+        return json_data
 
-    def parse_querystring(self, req, name, field):
+    def parse_querystring(self, req):
         """Pull a querystring value from the request."""
-        return core.get_value(req.args, name, field)
+        return req.args
 
-    def parse_form(self, req, name, field):
+    def parse_form(self, req):
         """Pull a form value from the request."""
         try:
-            return core.get_value(req.form, name, field)
+            return req.form
         except AttributeError:
             pass
-        return core.missing
+        return {}
 
-    def parse_headers(self, req, name, field):
+    def parse_headers(self, req):
         """Pull a value from the header data."""
-        return core.get_value(req.headers, name, field)
+        return req.headers
 
-    def parse_cookies(self, req, name, field):
+    def parse_cookies(self, req):
         """Pull a value from the cookiejar."""
-        return core.get_value(req.cookies, name, field)
+        return req.cookies
 
-    def parse_files(self, req, name, field):
+    def parse_files(self, req):
         """Pull a file from the request."""
-        return core.get_value(req.files, name, field)
+        return req.files
 
     def handle_error(self, error):
         """Handles errors during parsing. Aborts the current HTTP request and

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -28,7 +28,7 @@ Example usage: ::
 import collections
 import functools
 
-from webob.multidict import MultiDict, NoVars
+from webob.multidict import MultiDict
 from pyramid.httpexceptions import exception_response
 
 from marshmallow.compat import text_type
@@ -126,7 +126,6 @@ class PyramidParser(core.Parser):
 
     def _flatten_multidict(self, multidict):
         flat = multidict.dict_of_lists()
-        print(flat)
         for key, value in flat.items():
             if len(value) == 1:
                 flat[key] = value[0]

--- a/webargs/webapp2parser.py
+++ b/webargs/webapp2parser.py
@@ -30,7 +30,6 @@ Example: ::
 from webargs import core
 import webapp2
 import webapp2_extras.json
-import webob.multidict
 
 
 class Webapp2Parser(core.Parser):
@@ -57,7 +56,10 @@ class Webapp2Parser(core.Parser):
         return req.cookies
 
     def parse_headers(self, req):
-        """Pull a value from the header data."""
+        """Pull a value from the header data.
+
+        This also does case normalisation which is a problem
+        """
         headers = {}
         for key, value in req.headers.items():
             headers[key] = value


### PR DESCRIPTION
This PR attempts to address problems raised in #173 that Marshmallow validation methods never get to see the full set of arguments passed, even if pass_original is given. 
This PR changes the way that webargs reads arguments from the request, changing argument retrieval to create a full dictionary of possible parameters

This does introduce a problem with the webapp2 parser where the headers are case-insensitive, but that is probably addressable if the general idea of the PR is okay. 