### PR TITLE
In marshmallow 3, data_key replaces load_from

### DIFF
--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -131,9 +131,11 @@ def echo_nested_many(request):
     return json_response(parsed)
 
 @asyncio.coroutine
-def echo_nested_many_load_from(request):
+def echo_nested_many_data_key(request):
+    data_key_kwarg = {
+        'load_from' if (MARSHMALLOW_VERSION_INFO[0] < 3) else 'data_key': 'X-Field'}
     args = {
-        'x_field': fields.Nested({'id': fields.Int()}, load_from='X-Field', many=True)
+        'x_field': fields.Nested({'id': fields.Int()}, many=True, **data_key_kwarg)
     }
     parsed = yield from parser.parse(args, request)
     return json_response(parsed)
@@ -190,7 +192,7 @@ def create_app():
     add_route(app, ['POST'], '/echo_nested', echo_nested)
     add_route(app, ['POST'], '/echo_multiple_args', echo_multiple_args)
     add_route(app, ['POST'], '/echo_nested_many', echo_nested_many)
-    add_route(app, ['POST'], '/echo_nested_many_load_from', echo_nested_many_load_from)
+    add_route(app, ['POST'], '/echo_nested_many_data_key', echo_nested_many_data_key)
     add_route(app, ['GET'], '/echo_match_info/{mymatch}', echo_match_info)
     add_route(app, ['GET'], '/echo_method', EchoHandler().get)
     add_route(app, ['GET'], '/echo_method_view', EchoHandlerView)

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -124,10 +124,12 @@ def echo_nested_many():
     }
     return J(parser.parse(args))
 
-@app.route('/echo_nested_many_load_from', methods=['POST'])
-def echo_nested_many_with_load_from():
+@app.route('/echo_nested_many_data_key', methods=['POST'])
+def echo_nested_many_with_data_key():
+    data_key_kwarg = {
+        'load_from' if (MARSHMALLOW_VERSION_INFO[0] < 3) else 'data_key': 'X-Field'}
     args = {
-        'x_field': fields.Nested({'id': fields.Int()}, load_from='X-Field', many=True)
+        'x_field': fields.Nested({'id': fields.Int()}, many=True, **data_key_kwarg)
     }
     return J(parser.parse(args))
 

--- a/tests/test_aiohttpparser.py
+++ b/tests/test_aiohttpparser.py
@@ -39,16 +39,16 @@ class TestAIOHTTPParser(CommonTestCase):
         assert res.json == {'first': '1', 'last': '2'}
 
     # regression test for https://github.com/sloria/webargs/issues/145
-    def test_nested_many_with_load_from(self, testapp):
-        res = testapp.post_json('/echo_nested_many_load_from', {'x_field': [{'id': 42}]})
+    def test_nested_many_with_data_key(self, testapp):
+        res = testapp.post_json('/echo_nested_many_data_key', {'x_field': [{'id': 42}]})
         # https://github.com/marshmallow-code/marshmallow/pull/714
         if MARSHMALLOW_VERSION_INFO[0] < 3:
             assert res.json == {'x_field': [{'id': 42}]}
 
-        res = testapp.post_json('/echo_nested_many_load_from', {'X-Field': [{'id': 24}]})
+        res = testapp.post_json('/echo_nested_many_data_key', {'X-Field': [{'id': 24}]})
         assert res.json == {'x_field': [{'id': 24}]}
 
-        res = testapp.post_json('/echo_nested_many_load_from', {})
+        res = testapp.post_json('/echo_nested_many_data_key', {})
         assert res.json == {}
 
     def test_schema_as_kwargs_view(self, testapp):

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -45,16 +45,16 @@ class TestFlaskParser(CommonTestCase):
         assert res.json == {'username': 'foo'}
 
     # regression test for https://github.com/sloria/webargs/issues/145
-    def test_nested_many_with_load_from(self, testapp):
-        res = testapp.post_json('/echo_nested_many_load_from', {'x_field': [{'id': 42}]})
+    def test_nested_many_with_data_key(self, testapp):
+        res = testapp.post_json('/echo_nested_many_data_key', {'x_field': [{'id': 42}]})
         # https://github.com/marshmallow-code/marshmallow/pull/714
         if MARSHMALLOW_VERSION_INFO[0] < 3:
             assert res.json == {'x_field': [{'id': 42}]}
 
-        res = testapp.post_json('/echo_nested_many_load_from', {'X-Field': [{'id': 24}]})
+        res = testapp.post_json('/echo_nested_many_data_key', {'X-Field': [{'id': 24}]})
         assert res.json == {'x_field': [{'id': 24}]}
 
-        res = testapp.post_json('/echo_nested_many_load_from', {})
+        res = testapp.post_json('/echo_nested_many_data_key', {})
         assert res.json == {}
 
 

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -41,12 +41,16 @@ class AsyncParser(core.Parser):
             argdict = schema.fields
             parsed = {}
             for argname, field_obj in iteritems(argdict):
-                parsed_value = yield from self.parse_arg(argname, field_obj, req, locations)
-                # If load_from is specified on the field, try to parse from that key
-                if parsed_value is missing and field_obj.load_from:
-                    parsed_value = yield from self.parse_arg(field_obj.load_from,
-                                                             field_obj, req, locations)
-                    argname = field_obj.load_from
+                if core.MARSHMALLOW_VERSION_INFO[0] < 3:
+                    parsed_value = yield from self.parse_arg(argname, field_obj, req, locations)
+                    # If load_from is specified on the field, try to parse from that key
+                    if parsed_value is missing and field_obj.load_from:
+                        parsed_value = yield from self.parse_arg(field_obj.load_from,
+                                                                 field_obj, req, locations)
+                        argname = field_obj.load_from
+                else:
+                    argname = field_obj.data_key or argname
+                    parsed_value = yield from self.parse_arg(argname, field_obj, req, locations)
                 if parsed_value is not missing:
                     parsed[argname] = parsed_value
         return parsed

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -280,11 +280,16 @@ class Parser(object):
             argdict = schema.fields
             parsed = {}
             for argname, field_obj in iteritems(argdict):
-                parsed_value = self.parse_arg(argname, field_obj, req, locations)
-                # If load_from is specified on the field, try to parse from that key
-                if parsed_value is missing and field_obj.load_from:
-                    parsed_value = self.parse_arg(field_obj.load_from, field_obj, req, locations)
-                    argname = field_obj.load_from
+                if MARSHMALLOW_VERSION_INFO[0] < 3:
+                    parsed_value = self.parse_arg(argname, field_obj, req, locations)
+                    # If load_from is specified on the field, try to parse from that key
+                    if parsed_value is missing and field_obj.load_from:
+                        parsed_value = self.parse_arg(
+                            field_obj.load_from, field_obj, req, locations)
+                        argname = field_obj.load_from
+                else:
+                    argname = field_obj.data_key or argname
+                    parsed_value = self.parse_arg(argname, field_obj, req, locations)
                 if parsed_value is not missing:
                     parsed[argname] = parsed_value
         return parsed

--- a/webargs/fields.py
+++ b/webargs/fields.py
@@ -9,10 +9,11 @@ where to parse the request argument from. ::
 
     args = {
         'active': fields.Bool(location='query')
-        'content_type': fields.Str(load_from='Content-Type',
+        'content_type': fields.Str(data_key='Content-Type',
                                    location='headers')
     }
 
+Note: `data_key` replaced `load_from` in marshmallow 3. When using marshmallow 2, use `load_from`.
 """
 import marshmallow as ma
 


### PR DESCRIPTION
It could look like there is duplication in core. This is because the change is not only the parameter renaming, but also the fact that in MA3, the attribute name is not checked when `data_key` is specified, which allows to simplify the logic.

Besides, in those cases, I prefer duplication to complicated logic because ultimately, the old compatibility code will be dropped and we'll be left with the simple case.