### PR TITLE
Minor refactor in core.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+3.0.0 (unreleased)
+******************
+
+Changes :
+
+* Remove unused ``instance`` and ``kwargs`` arguments of ``argmap2schema``
+* Remove ``Parser.load`` method (``Parser`` now calls ``Schema.load`` directly)
+
+Those changes shouldn't affect most users. However, they might break custom parsers calling these methods. (:issue: `222`)
+
 2.1.0 (2018-04-01)
 ******************
 

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -69,7 +69,7 @@ class AsyncParser(core.Parser):
         schema = self._get_schema(argmap, req)
         try:
             parsed = yield from self._parse_request(schema=schema, req=req, locations=locations)
-            result = self.load(parsed, schema)
+            result = schema.load(parsed)
             data = result.data if core.MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -84,7 +84,7 @@ def fill_in_missing_args(ret, argmap):
         ret[key] = missing
     return ret
 
-def argmap2schema(argmap, instance=False, **kwargs):
+def argmap2schema(argmap):
     """Generate a `marshmallow.Schema` class given a dictionary of argument
     names to `Fields <marshmallow.fields.Field>`.
     """
@@ -93,8 +93,7 @@ def argmap2schema(argmap, instance=False, **kwargs):
         class Meta(object):
             strict = True
         attrs['Meta'] = Meta
-    cls = type(str(''), (ma.Schema,), attrs)
-    return cls if not instance else cls(**kwargs)
+    return type(str(''), (ma.Schema,), attrs)
 
 def is_multiple(field):
     """Return whether or not `field` handles repeated/multi-value arguments."""

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -293,12 +293,6 @@ class Parser(object):
                     parsed[argname] = parsed_value
         return parsed
 
-    def load(self, data, schema):
-        if MARSHMALLOW_VERSION_INFO[0] < 3 and not schema.strict:
-            warnings.warn('It is highly recommended that you set strict=True on your schema '
-                "so that the parser's error handler will be invoked when expected.", UserWarning)
-        return schema.load(data)
-
     def _on_validation_error(self, error):
         if (isinstance(error, ma.exceptions.ValidationError) and not
                 isinstance(error, ValidationError)):
@@ -338,6 +332,9 @@ class Parser(object):
             schema = argmap(req)
         else:
             schema = argmap2schema(argmap)()
+        if MARSHMALLOW_VERSION_INFO[0] < 3 and not schema.strict:
+            warnings.warn('It is highly recommended that you set strict=True on your schema '
+                "so that the parser's error handler will be invoked when expected.", UserWarning)
         return schema
 
     def parse(self, argmap, req=None, locations=None, validate=None, force_all=False):
@@ -363,7 +360,7 @@ class Parser(object):
         schema = self._get_schema(argmap, req)
         try:
             parsed = self._parse_request(schema=schema, req=req, locations=locations)
-            result = self.load(parsed, schema)
+            result = schema.load(parsed)
             data = result.data if MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -293,11 +293,7 @@ class Parser(object):
                     parsed[argname] = parsed_value
         return parsed
 
-    def load(self, data, argmap):
-        if isinstance(argmap, ma.Schema):
-            schema = argmap
-        else:
-            schema = argmap2schema(argmap)()
+    def load(self, data, schema):
         if MARSHMALLOW_VERSION_INFO[0] < 3 and not schema.strict:
             warnings.warn('It is highly recommended that you set strict=True on your schema '
                 "so that the parser's error handler will be invoked when expected.", UserWarning)


### PR DESCRIPTION
Closes #216.

This simplifies the code a bit.

No test broken. However, any custom parser that overrides `Parser.parse` (`or AsyncParser.parse`) and calls `Parser.load` requires a little adaptation.

Does that make it a breaking change? The docs read

> To add your own parser, extend Parser and implement the parse_* method(s) you need to override. 

`Parser.parse` and `Parser.load` are not exposed, so it can be argued that the API is not changed.