### PR TITLE
Skip aiohttp tests for python<3.5; Drop support for aiohttp<3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ python:
 
 install:
     - travis_retry pip install -U .
-    - if [[ $TRAVIS_PYTHON_VERSION == 2* || $TRAVIS_PYTHON_VERSION == 'pypy' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then travis_retry pip install -r dev-requirements.txt; fi
-    # NOTE: aiohttp is not supported on 3.3
-    - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then travis_retry pip install -r dev-requirements-py3.txt; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2* || $TRAVIS_PYTHON_VERSION == 3.4* || $TRAVIS_PYTHON_VERSION == 'pypy' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then travis_retry pip install -r dev-requirements.txt; fi
+    # NOTE: aiohttp supports python>=3.5
+    - if [[ $TRAVIS_PYTHON_VERSION == 3* && $TRAVIS_PYTHON_VERSION != 3.4* ]] ; then travis_retry pip install -r dev-requirements-py3.txt; fi
     - travis_retry pip install -U marshmallow"$MARSHMALLOW_VERSION" --pre
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,12 +4,14 @@ Changelog
 3.0.0 (unreleased)
 ******************
 
-Changes :
+Changes:
 
-* Remove unused ``instance`` and ``kwargs`` arguments of ``argmap2schema``
-* Remove ``Parser.load`` method (``Parser`` now calls ``Schema.load`` directly)
+* Remove unused ``instance`` and ``kwargs`` arguments of ``argmap2schema``.
+* Remove ``Parser.load`` method (``Parser`` now calls ``Schema.load`` directly).
 
-Those changes shouldn't affect most users. However, they might break custom parsers calling these methods. (:issue: `222`)
+These changes shouldn't affect most users. However, they might break custom parsers calling these methods. (:issue: `222`)
+
+* Drop support for aiohttp<3.0.0.
 
 2.1.0 (2018-04-01)
 ******************

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,5 +1,4 @@
 -r dev-requirements.txt
-# webtest-aiohttp doesn't yet support aiohttp>=2.0.0
-aiohttp>=2.3.8
+aiohttp>=3.0.0
 webtest-aiohttp==2.0.0
 pytest-aiohttp>=0.3.0

--- a/tasks.py
+++ b/tasks.py
@@ -17,13 +17,11 @@ def test(ctx, coverage=False, browse=False):
         args.extend(['--cov=webargs', '--cov-report=term', '--cov-report=html'])
 
     ignores = []
-    if sys.version_info < (3, 4, 1):
+    # aiohttp support python>=3.5
+    if sys.version_info < (3, 5):
         ignores += [
-            os.path.join('tests', 'test_aiohttpparser.py')
-        ]
-    if sys.version_info < (3, 5, 0):
-        ignores += [
-            os.path.join('tests', 'test_aiohttpparser_async_functions.py')
+            os.path.join('tests', 'test_aiohttpparser.py'),
+            os.path.join('tests', 'test_aiohttpparser_async_functions.py'),
         ]
     if ignores:
         for each in ignores:


### PR DESCRIPTION
Newer aiohttp versions drop py34 support