### PR TITLE
Pass request to error handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,23 @@ Changelog
 
 Changes:
 
-* Remove unused ``instance`` and ``kwargs`` arguments of ``argmap2schema``.
-* Remove ``Parser.load`` method (``Parser`` now calls ``Schema.load`` directly).
+* *Backwards-incompatible*: Custom error handlers receive the request object as the second
+  argument. Update any decorated functions to take a `req` argument, like so:
+
+.. code-block:: python
+
+    # 2.x
+    @parser.error_handler
+    def handle_error(error):
+        raise CustomError(error.messages)
+
+    # 3.x
+    @parser.error_handler
+    def handle_error(error, req):
+        raise CustomError(error.messages)
+
+* *Backwards-incompatible*: Remove unused ``instance`` and ``kwargs`` arguments of ``argmap2schema``.
+* *Backwards-incompatible*: Remove ``Parser.load`` method (``Parser`` now calls ``Schema.load`` directly).
 
 These changes shouldn't affect most users. However, they might break custom parsers calling these methods. (:issue: `222`)
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -186,7 +186,9 @@ The full arguments dictionary can also be validated by passing ``validate`` to :
 Error Handling
 --------------
 
-Each parser has a default error handling method. To override the error handling callback, write a function that receives an error and handles it, then decorate that function with :func:`Parser.error_handler <webargs.core.Parser.error_handler>`.
+Each parser has a default error handling method. To override the error handling callback, write a function that
+receives an error and the request and handles the error.
+Then decorate that function with :func:`Parser.error_handler <webargs.core.Parser.error_handler>`.
 
 .. code-block:: python
 
@@ -197,7 +199,7 @@ Each parser has a default error handling method. To override the error handling 
         pass
 
     @parser.error_handler
-    def handle_error(error):
+    def handle_error(error, req):
         raise CustomError(error.messages)
 
 Nesting Fields

--- a/examples/flaskrestful_example.py
+++ b/examples/flaskrestful_example.py
@@ -71,7 +71,7 @@ class DateAddResource(Resource):
 
 # This error handler is necessary for usage with Flask-RESTful
 @parser.error_handler
-def handle_request_parsing_error(err):
+def handle_request_parsing_error(err, req):
     """webargs error handler that uses Flask-RESTful's abort function to return
     a JSON error response to the client.
     """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -213,10 +213,10 @@ def test_handle_error_called_when_parsing_raises_error(parse_json, handle_error,
     p.parse({'foo': fields.Field()}, web_request, locations=('json',))
     assert handle_error.call_count == 2
 
-def test_handle_error_reraises_errors():
+def test_handle_error_reraises_errors(web_request):
     p = Parser()
     with pytest.raises(ValidationError):
-        p.handle_error(ValidationError('error raised'))
+        p.handle_error(ValidationError('error raised'), web_request)
 
 @mock.patch('webargs.core.Parser.parse_headers')
 def test_locations_as_init_arguments(parse_headers, web_request):
@@ -235,7 +235,7 @@ def test_custom_error_handler(parse_json, web_request):
     class CustomError(Exception):
         pass
 
-    def error_handler(error):
+    def error_handler(error, req):
         raise CustomError(error)
     parse_json.side_effect = ValidationError('parse_json failed')
     p = Parser(error_handler=error_handler)
@@ -252,7 +252,7 @@ def test_custom_error_handler_decorator(parse_json, web_request):
     parser = Parser()
 
     @parser.error_handler
-    def handle_error(error):
+    def handle_error(error, req):
         raise CustomError(error)
 
     with pytest.raises(CustomError):

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -134,7 +134,7 @@ class AIOHTTPParser(AsyncParser):
         assert isinstance(req, web.Request), 'Request argument not found for handler'
         return req
 
-    def handle_error(self, error):
+    def handle_error(self, error, req):
         """Handle ValidationErrors and return a JSON response of error messages to the client."""
         error_class = exception_map.get(error.status_code)
         if not error_class:

--- a/webargs/async.py
+++ b/webargs/async.py
@@ -73,7 +73,7 @@ class AsyncParser(core.Parser):
             data = result.data if core.MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:
-            self._on_validation_error(error)
+            self._on_validation_error(error, req)
         finally:
             self.clear_cache()
         if force_all:

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -57,7 +57,7 @@ class BottleParser(core.Parser):
         """Pull a file from the request."""
         return core.get_value(req.files, name, field)
 
-    def handle_error(self, error):
+    def handle_error(self, error, req):
         """Handles errors during parsing. Aborts the current request with a
         400 error.
         """

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -293,7 +293,7 @@ class Parser(object):
                     parsed[argname] = parsed_value
         return parsed
 
-    def _on_validation_error(self, error):
+    def _on_validation_error(self, error, req):
         if (isinstance(error, ma.exceptions.ValidationError) and not
                 isinstance(error, ValidationError)):
             # Raise a webargs error instead
@@ -305,9 +305,9 @@ class Parser(object):
                 **getattr(error, 'kwargs', {})
             )
         if self.error_callback:
-            self.error_callback(error)
+            self.error_callback(error, req)
         else:
-            self.handle_error(error)
+            self.handle_error(error, req)
 
     def _validate_arguments(self, data, validators):
         for validator in validators:
@@ -364,7 +364,7 @@ class Parser(object):
             data = result.data if MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:
-            self._on_validation_error(error)
+            self._on_validation_error(error, req)
         finally:
             self.clear_cache()
         if force_all:
@@ -490,7 +490,7 @@ class Parser(object):
 
     def error_handler(self, func):
         """Decorator that registers a custom error handling function. The
-        function should received the raised error. Overrides
+        function should received the raised error and the request object. Overrides
         the parser's ``handle_error`` method.
 
         Example: ::
@@ -502,7 +502,7 @@ class Parser(object):
                 pass
 
             @parser.error_handler
-            def handle_error(error):
+            def handle_error(error, request):
                 raise CustomError(error)
 
         :param callable func: The error callback to register.
@@ -548,7 +548,7 @@ class Parser(object):
         """
         return missing
 
-    def handle_error(self, error):
+    def handle_error(self, error, req):
         """Called if an error occurs while parsing args. By default, just logs and
         raises ``error``.
         """

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -132,7 +132,7 @@ class FalconParser(core.Parser):
         raise NotImplementedError('Parsing files not yet supported by {0}'
             .format(self.__class__.__name__))
 
-    def handle_error(self, error):
+    def handle_error(self, error, req):
         """Handles errors during parsing."""
         status = status_map.get(error.status_code)
         if status is None:

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -96,7 +96,7 @@ class FlaskParser(core.Parser):
         """Pull a file from the request."""
         return core.get_value(req.files, name, field)
 
-    def handle_error(self, error):
+    def handle_error(self, error, req):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 422 error.
         """

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -75,7 +75,7 @@ class PyramidParser(core.Parser):
         """Pull a value from the request's `matchdict`."""
         return core.get_value(req.matchdict, name, field)
 
-    def handle_error(self, error):
+    def handle_error(self, error, req):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 400 error.
         """

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -109,7 +109,7 @@ class TornadoParser(core.Parser):
         """Pull a file from the request."""
         return get_value(req.files, name, field)
 
-    def handle_error(self, error):
+    def handle_error(self, error, req):
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`
         with a 400 error.
         """


### PR DESCRIPTION
With this change, error handlers receive the request object.

```python
# Before
@parser.error_handler
def handle_error(error):
    raise CustomError(error.messages)

# After
@parser.error_handler
def handle_error(error, req):
    raise CustomError(error.messages)
```

This allows error handlers to use information in the request when handling errors.