### PR TITLE
Pass schema instance to error handlers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,30 @@ Changelog
 4.0.0 (unreleased)
 ******************
 
+Features:
+
+* *Backwards-incompatible*: Custom error handlers receive the
+  `marshmallow.Schema` instance as the third argument. Update any
+  functions decorated with `Parser.error_handler` to take a ``schema``
+  argument, like so:
+
+.. code-block:: python
+
+    # 3.x
+    @parser.error_handler
+    def handle_error(error, req):
+        raise CustomError(error.messages)
+
+
+    # 4.x
+    @parser.error_handler
+    def handle_error(error, req, schema):
+        raise CustomError(error.messages)
+
+
+See `marshmallow-code/marshmallow#840 (comment) <https://github.com/marshmallow-code/marshmallow/issues/840#issuecomment-403481686>`_
+for more information about this change.
+
 Bug fixes:
 
 * *Backwards-incompatible*: Rename ``webargs.async`` to

--- a/docs/framework_support.rst
+++ b/docs/framework_support.rst
@@ -31,7 +31,8 @@ When using the :meth:`use_args <webargs.flaskparser.FlaskParser.use_args>` decor
 Error Handling
 ++++++++++++++
 
-Webargs uses Flask's ``abort`` function to raise an ``HTTPException`` when a validation error occurs. If you use the ``Flask.errorhandler`` method to handle errors, you can access validation messages from the ``data`` attribute of an error.
+Webargs uses Flask's ``abort`` function to raise an ``HTTPException`` when a validation error occurs.
+If you use the ``Flask.errorhandler`` method to handle errors, you can access validation messages from the ``data`` attribute of an error.
 
 Here is an example error handler that returns validation messages to the client as JSON.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -185,14 +185,14 @@ Error Handling
 --------------
 
 Each parser has a default error handling method. To override the error handling callback, write a function that
-receives an error and the request and handles the error.
+receives an error, the request, and the `marshmallow.Schema` instance.
 Then decorate that function with :func:`Parser.error_handler <webargs.core.Parser.error_handler>`.
 
 .. code-block:: python
 
-    from webargs import core
+    from webargs import flaskparser
 
-    parser = core.Parser()
+    parser = flaskparser.FlaskParser()
 
 
     class CustomError(Exception):
@@ -200,7 +200,7 @@ Then decorate that function with :func:`Parser.error_handler <webargs.core.Parse
 
 
     @parser.error_handler
-    def handle_error(error, req):
+    def handle_error(error, req, schema):
         raise CustomError(error.messages)
 
 Nesting Fields

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -183,4 +183,5 @@ def echo_use_kwargs_missing(username, password):
 # Return validation errors as JSON
 @app.errorhandler(422)
 def handle_validation_error(err):
+    assert isinstance(err.data["schema"], ma.Schema)
     return J({"errors": err.exc.messages}), 422

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -265,7 +265,7 @@ def test_handle_error_called_when_parsing_raises_error(
 def test_handle_error_reraises_errors(web_request):
     p = Parser()
     with pytest.raises(ValidationError):
-        p.handle_error(ValidationError("error raised"), web_request)
+        p.handle_error(ValidationError("error raised"), web_request, Schema())
 
 
 @mock.patch("webargs.core.Parser.parse_headers")
@@ -287,7 +287,8 @@ def test_custom_error_handler(parse_json, web_request):
     class CustomError(Exception):
         pass
 
-    def error_handler(error, req):
+    def error_handler(error, req, schema):
+        assert isinstance(schema, Schema)
         raise CustomError(error)
 
     parse_json.side_effect = ValidationError("parse_json failed")
@@ -306,7 +307,8 @@ def test_custom_error_handler_decorator(parse_json, web_request):
     parser = Parser()
 
     @parser.error_handler
-    def handle_error(error, req):
+    def handle_error(error, req, schema):
+        assert isinstance(schema, Schema)
         raise CustomError(error)
 
     with pytest.raises(CustomError):

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -132,7 +132,7 @@ class AIOHTTPParser(AsyncParser):
         assert isinstance(req, web.Request), "Request argument not found for handler"
         return req
 
-    def handle_error(self, error, req):
+    def handle_error(self, error, req, schema):
         """Handle ValidationErrors and return a JSON response of error messages to the client."""
         error_class = exception_map.get(error.status_code)
         if not error_class:

--- a/webargs/asyncparser.py
+++ b/webargs/asyncparser.py
@@ -76,7 +76,7 @@ class AsyncParser(core.Parser):
             data = result.data if core.MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:
-            self._on_validation_error(error, req)
+            self._on_validation_error(error, req, schema)
         finally:
             self.clear_cache()
         if force_all:

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -57,7 +57,7 @@ class BottleParser(core.Parser):
         """Pull a file from the request."""
         return core.get_value(req.files, name, field)
 
-    def handle_error(self, error, req):
+    def handle_error(self, error, req, schema):
         """Handles errors during parsing. Aborts the current request with a
         400 error.
         """

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -140,7 +140,7 @@ class FalconParser(core.Parser):
             "Parsing files not yet supported by {0}".format(self.__class__.__name__)
         )
 
-    def handle_error(self, error, req):
+    def handle_error(self, error, req, schema):
         """Handles errors during parsing."""
         status = status_map.get(error.status_code)
         if status is None:

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -93,12 +93,12 @@ class FlaskParser(core.Parser):
         """Pull a file from the request."""
         return core.get_value(req.files, name, field)
 
-    def handle_error(self, error, req):
+    def handle_error(self, error, req, schema):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 422 error.
         """
         status_code = getattr(error, "status_code", self.DEFAULT_VALIDATION_STATUS)
-        abort(status_code, messages=error.messages, exc=error)
+        abort(status_code, exc=error, messages=error.messages, schema=schema)
 
     def get_default_request(self):
         """Override to use Flask's thread-local request objec by default"""

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -73,7 +73,7 @@ class PyramidParser(core.Parser):
         """Pull a value from the request's `matchdict`."""
         return core.get_value(req.matchdict, name, field)
 
-    def handle_error(self, error, req):
+    def handle_error(self, error, req, schema):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 400 error.
         """

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -113,7 +113,7 @@ class TornadoParser(core.Parser):
         """Pull a file from the request."""
         return get_value(req.files, name, field)
 
-    def handle_error(self, error, req):
+    def handle_error(self, error, req, schema):
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`
         with a 400 error.
         """


### PR DESCRIPTION
* @error_handler and handle_error receive schema instance
* In Flask, the Schema instance is attached to HTTPExceptions and
  is accessible from error.data["schema"]

See https://github.com/marshmallow-code/marshmallow/issues/840#issuecomment-403481686