### PR TITLE
aiohttpparser: Fix 500 error with JSON content-type and empty body

### DIFF
--- a/tests/test_aiohttpparser.py
+++ b/tests/test_aiohttpparser.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
+import webtest
 import webtest_aiohttp
 import pytest
 
+from io import BytesIO
 from webargs.core import MARSHMALLOW_VERSION_INFO
 from webargs.testing import CommonTestCase
 from tests.apps.aiohttp_app import create_app
@@ -63,3 +65,10 @@ class TestAIOHTTPParser(CommonTestCase):
         assert testapp.get("/echo_use_schema_as_kwargs?name=Chandler").json == {
             "name": "Chandler"
         }
+
+    # https://github.com/sloria/webargs/pull/297
+    def test_empty_json_body(self, testapp):
+        environ = {"CONTENT_TYPE": "application/json", "wsgi.input": BytesIO(b"")}
+        req = webtest.TestRequest.blank("/echo", environ)
+        resp = testapp.do_request(req)
+        assert resp.json == {"name": "World"}

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -97,7 +97,14 @@ class AIOHTTPParser(AsyncParser):
         if json_data is None:
             if not (req.body_exists and is_json_request(req)):
                 return core.missing
-            self._cache["json"] = json_data = await req.json()
+            try:
+                json_data = await req.json()
+            except json.JSONDecodeError as e:
+                if e.doc == '':
+                    return core.missing
+                else:
+                    raise e
+            self._cache["json"] = json_data
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_headers(self, req, name, field):

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -100,7 +100,7 @@ class AIOHTTPParser(AsyncParser):
             try:
                 json_data = await req.json()
             except json.JSONDecodeError as e:
-                if e.doc == '':
+                if e.doc == "":
                     return core.missing
                 else:
                     raise e


### PR DESCRIPTION
Fixes 500 errors when Content-Type is JSON and the request body is empty.
This is done by catching the resulting JSONDecodeError and checking whether the input is empty.