### PR TITLE
Bump marshmallow requirement version to >=2.15.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Requirements
-marshmallow
+marshmallow>=2.15.2
 
 # Task running
 invoke==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 from setuptools import setup, find_packages
 
 # Requirements
-REQUIREMENTS = ["marshmallow>=2.15.0"]
+REQUIREMENTS = ["marshmallow>=2.15.2"]
 
 
 def find_version(fname):


### PR DESCRIPTION
This version includes fixes for

- https://github.com/marshmallow-code/marshmallow/issues/772 (Empty Only Treated as None) [CVE-2018-17175]
- https://github.com/marshmallow-code/marshmallow/issues/785 (Thread-safety issue in error structure)

Hopefully, this should make Tidelift happy.

While upgrading to 2.15.1 for CVE-2018-17175, I figured I'd go to 2.15.2 as the thread safety issue in marshmallow can be problematic when used with webargs to parse inputs in a threaded server (this is how we discovered the problem).