### PR TITLE
fix DelimitedList serialize bug

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,3 +37,4 @@ Contributors (chronological)
 * @Reskov <https://github.com/Reskov>
 * @cedzz <https://github.com/cedzz>
 * F. Moukayed (כוכב) <https://github.com/kochab>
+* Xiaoyu Lee <https://github.com/lee3164>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -882,18 +882,25 @@ def test_delimited_list_as_string(web_request, parser):
 
 
 def test_delimited_list_as_string_v2(web_request, parser):
-	web_request.json = {"dates": "2018-11-01,2018-11-02"}
-	schema_cls = argmap2schema(
-		{"dates": fields.DelimitedList(fields.DateTime(format="%Y-%m-%d"), as_string=True)}
-	)
-	schema = schema_cls()
+    web_request.json = {"dates": "2018-11-01,2018-11-02"}
+    schema_cls = argmap2schema(
+        {
+            "dates": fields.DelimitedList(
+                fields.DateTime(format="%Y-%m-%d"), as_string=True
+            )
+        }
+    )
+    schema = schema_cls()
 
-	parsed = parser.parse(schema, web_request)
-	assert parsed["dates"] == [datetime.datetime(2018, 11, 1), datetime.datetime(2018, 11, 2)]
+    parsed = parser.parse(schema, web_request)
+    assert parsed["dates"] == [
+        datetime.datetime(2018, 11, 1),
+        datetime.datetime(2018, 11, 2),
+    ]
 
-	dumped = schema.dump(parsed)
-	data = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
-	assert data["dates"] == "2018-11-01,2018-11-02"
+    dumped = schema.dump(parsed)
+    data = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
+    assert data["dates"] == "2018-11-01,2018-11-02"
 
 
 def test_delimited_list_custom_delimiter(web_request, parser):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -882,7 +882,6 @@ def test_delimited_list_as_string(web_request, parser):
 
 
 def test_delimited_list_as_string_v2(web_request, parser):
-	# b26793ee8021b6cfe525ac4f05570c3c68a4debd commit info
 	web_request.json = {"dates": "2018-11-01,2018-11-02"}
 	schema_cls = argmap2schema(
 		{"dates": fields.DelimitedList(fields.DateTime(format="%Y-%m-%d"), as_string=True)}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 import itertools
 import mock
 import sys
+import datetime
 
 import pytest
 from marshmallow import Schema, post_load, class_registry, validates_schema
@@ -878,6 +879,22 @@ def test_delimited_list_as_string(web_request, parser):
     dumped = schema.dump(parsed)
     data = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
     assert data["ids"] == "1,2,3"
+
+
+def test_delimited_list_as_string_v2(web_request, parser):
+	# b26793ee8021b6cfe525ac4f05570c3c68a4debd commit info
+	web_request.json = {"dates": "2018-11-01,2018-11-02"}
+	schema_cls = argmap2schema(
+		{"dates": fields.DelimitedList(fields.DateTime(format="%Y-%m-%d"), as_string=True)}
+	)
+	schema = schema_cls()
+
+	parsed = parser.parse(schema, web_request)
+	assert parsed["dates"] == [datetime.datetime(2018, 11, 1), datetime.datetime(2018, 11, 2)]
+
+	dumped = schema.dump(parsed)
+	data = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
+	assert data["dates"] == "2018-11-01,2018-11-02"
 
 
 def test_delimited_list_custom_delimiter(web_request, parser):

--- a/webargs/fields.py
+++ b/webargs/fields.py
@@ -58,7 +58,7 @@ class DelimitedList(ma.fields.List):
     def _serialize(self, value, attr, obj):
         ret = super(DelimitedList, self)._serialize(value, attr, obj)
         if self.as_string:
-            return self.delimiter.join(format(each) for each in value)
+            return self.delimiter.join(format(each) for each in ret)
         return ret
 
     def _deserialize(self, value, attr, data):


### PR DESCRIPTION
DelimitedList should use it's parents serialize results when as_string is set
Change-Id: Ic7318703fce93c64373eabf1737e2480256eb557