### PR TITLE
Fixed bug with using multiple use_args decorators on the same aiohttp handler.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,3 +38,4 @@ Contributors (chronological)
 * @cedzz <https://github.com/cedzz>
 * F. Moukayed (כוכב) <https://github.com/kochab>
 * Xiaoyu Lee <https://github.com/lee3164>
+* Jonathan Angelo <https://github.com/jangelo>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+4.1.3 (unreleased)
+******************
+
+Bug fixes:
+
+* Fix bug in ``AIOHTTParser`` that prevented calling
+  ``use_args`` on the same view function multiple times (:issue:`273`).
+  Thanks to :user:`dnp1` for reporting and :user:`jangelo` for the fix.
+
 4.1.2 (2018-11-03)
 ******************
 

--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -73,6 +73,12 @@ async def echo_use_kwargs_with_path_param(request, value):
     return json_response({"value": value})
 
 
+@use_args({"page": fields.Int(), "q": fields.Int()}, locations=("query",))
+@use_args({"name": fields.Str()}, locations=("json",))
+async def echo_use_args_multiple(request, query_parsed, json_parsed):
+    return json_response({"query_parsed": query_parsed, "json_parsed": json_parsed})
+
+
 async def always_error(request):
     def always_fail(value):
         raise ValidationError("something went wrong")
@@ -193,6 +199,7 @@ def create_app():
         "/echo_use_kwargs_with_path_param/{name}",
         echo_use_kwargs_with_path_param,
     )
+    add_route(app, ["POST"], "/echo_use_args_multiple", echo_use_args_multiple)
     add_route(app, ["GET", "POST"], "/error", always_error)
     add_route(app, ["GET", "POST"], "/error400", error400)
     add_route(app, ["GET"], "/error_invalid", error_invalid)

--- a/tests/test_py3/test_aiohttpparser.py
+++ b/tests/test_py3/test_aiohttpparser.py
@@ -72,3 +72,12 @@ class TestAIOHTTPParser(CommonTestCase):
         req = webtest.TestRequest.blank("/echo", environ)
         resp = testapp.do_request(req)
         assert resp.json == {"name": "World"}
+
+    def test_use_args_multiple(self, testapp):
+        res = testapp.post_json(
+            "/echo_use_args_multiple?page=2&q=10", {"name": "Steve"}
+        )
+        assert res.json == {
+            "query_parsed": {"page": 2, "q": 10},
+            "json_parsed": {"name": "Steve"},
+        }

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -129,13 +129,14 @@ class AIOHTTPParser(AsyncParser):
         """Get request object from a handler function or method. Used internally by
         ``use_args`` and ``use_kwargs``.
         """
-        if len(args) > 1:
-            req = args[1]
-        else:
-            if isinstance(args[0], web.View):
-                req = args[0].request
-            else:
-                req = args[0]
+        req = None
+        for arg in args:
+            if isinstance(arg, web.Request):
+                req = arg
+                break
+            elif isinstance(arg, web.View):
+                req = arg.request
+                break
         assert isinstance(req, web.Request), "Request argument not found for handler"
         return req
 


### PR DESCRIPTION
This PR is to address the following issue:
https://github.com/sloria/webargs/issues/273

The issue with the previous code was when multiple use_args are present, the function `get_request_from_view_args` would be called for each one.  In this function, when the len(args) > 1, it would just take the value at arg[1] and assume it was the web.Request object.  This unfortunately is not the case when multiple use_args exist.  Instead, the fix is to scan the args list and find the web.Request object.

A unittest was added copying the use case as specified in the documentation.
https://webargs.readthedocs.io/en/latest/advanced.html#mixing-locations