### PR TITLE
Remove webargs.ValidationError and use marshmallow ValidationError instead

### DIFF
--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -5,7 +5,7 @@ from aiohttp.web import json_response
 from aiohttp import web
 import marshmallow as ma
 
-from webargs import fields, ValidationError
+from webargs import fields
 from webargs.aiohttpparser import parser, use_args, use_kwargs
 from webargs.core import MARSHMALLOW_VERSION_INFO
 
@@ -81,7 +81,7 @@ async def echo_use_args_multiple(request, query_parsed, json_parsed):
 
 async def always_error(request):
     def always_fail(value):
-        raise ValidationError("something went wrong")
+        raise ma.ValidationError("something went wrong")
 
     args = {"text": fields.Str(validate=always_fail)}
     parsed = await parser.parse(args, request)

--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -88,24 +88,6 @@ async def always_error(request):
     return json_response(parsed)
 
 
-async def error400(request):
-    def always_fail(value):
-        raise ValidationError("something went wrong", status_code=400)
-
-    args = {"text": fields.Str(validate=always_fail)}
-    parsed = await parser.parse(args, request)
-    return json_response(parsed)
-
-
-async def error_invalid(request):
-    def always_fail(value):
-        raise ValidationError("something went wrong", status_code=12345)
-
-    args = {"text": fields.Str(validate=always_fail)}
-    parsed = await parser.parse(args, request)
-    return json_response(parsed)
-
-
 async def echo_headers(request):
     parsed = await parser.parse(hello_args, request, locations=("headers",))
     return json_response(parsed)
@@ -201,8 +183,6 @@ def create_app():
     )
     add_route(app, ["POST"], "/echo_use_args_multiple", echo_use_args_multiple)
     add_route(app, ["GET", "POST"], "/error", always_error)
-    add_route(app, ["GET", "POST"], "/error400", error400)
-    add_route(app, ["GET"], "/error_invalid", error_invalid)
     add_route(app, ["GET"], "/echo_headers", echo_headers)
     add_route(app, ["GET"], "/echo_cookie", echo_cookie)
     add_route(app, ["POST"], "/echo_nested", echo_nested)

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -2,7 +2,7 @@ import json
 from bottle import Bottle, HTTPResponse, debug, request, response, error
 
 import marshmallow as ma
-from webargs import fields, ValidationError
+from webargs import fields
 from webargs.bottleparser import parser, use_args, use_kwargs
 from webargs.core import MARSHMALLOW_VERSION_INFO
 
@@ -76,7 +76,7 @@ def echo_use_kwargs_with_path_param(name, value):
 @app.route("/error", method=["GET", "POST"])
 def always_error():
     def always_fail(value):
-        raise ValidationError("something went wrong")
+        raise ma.ValidationError("something went wrong")
 
     args = {"text": fields.Str(validate=always_fail)}
     return parser.parse(args)

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -82,15 +82,6 @@ def always_error():
     return parser.parse(args)
 
 
-@app.route("/error400", method=["GET", "POST"])
-def error400():
-    def always_fail(value):
-        raise ValidationError("something went wrong", status_code=400)
-
-    args = {"text": fields.Str(validate=always_fail)}
-    return parser.parse(args)
-
-
 @app.route("/echo_headers")
 def echo_headers():
     return parser.parse(hello_args, request, locations=("headers",))

--- a/tests/apps/django_app/base/urls.py
+++ b/tests/apps/django_app/base/urls.py
@@ -18,7 +18,6 @@ urlpatterns = [
         views.echo_use_kwargs_with_path_param,
     ),
     url(r"^error$", views.always_error),
-    url(r"^error400$", views.error400),
     url(r"^echo_headers$", views.echo_headers),
     url(r"^echo_cookie$", views.echo_cookie),
     url(r"^echo_file$", views.echo_file),

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse
 from django.views.generic import View
 
 import marshmallow as ma
-from webargs import fields, ValidationError
+from webargs import fields
 from webargs.djangoparser import parser, use_args, use_kwargs
 from webargs.core import MARSHMALLOW_VERSION_INFO
 
@@ -26,7 +26,7 @@ def json_response(data, **kwargs):
 def echo(request):
     try:
         args = parser.parse(hello_args, request)
-    except ValidationError as err:
+    except ma.ValidationError as err:
         return json_response(err.messages, status=err.status_code)
     return json_response(args)
 
@@ -54,7 +54,7 @@ def echo_many_schema(request):
         return json_response(
             parser.parse(hello_many_schema, request, locations=("json",))
         )
-    except ValidationError as err:
+    except ma.ValidationError as err:
         return json_response(err.messages, status=err.status_code)
 
 
@@ -70,12 +70,12 @@ def echo_use_kwargs_with_path_param(request, value, name):
 
 def always_error(request):
     def always_fail(value):
-        raise ValidationError("something went wrong")
+        raise ma.ValidationError("something went wrong")
 
     argmap = {"text": fields.Str(validate=always_fail)}
     try:
         return parser.parse(argmap, request)
-    except ValidationError as err:
+    except ma.ValidationError as err:
         return json_response(err.messages, status=err.status_code)
 
 
@@ -111,7 +111,7 @@ class EchoCBV(View):
     def get(self, request):
         try:
             args = parser.parse(hello_args, self.request)
-        except ValidationError as err:
+        except ma.ValidationError as err:
             return json_response(err.messages, status=err.status_code)
         return json_response(args)
 

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -27,7 +27,7 @@ def echo(request):
     try:
         args = parser.parse(hello_args, request)
     except ma.ValidationError as err:
-        return json_response(err.messages, status=err.status_code)
+        return json_response(err.messages, status=parser.DEFAULT_VALIDATION_STATUS)
     return json_response(args)
 
 
@@ -55,7 +55,7 @@ def echo_many_schema(request):
             parser.parse(hello_many_schema, request, locations=("json",))
         )
     except ma.ValidationError as err:
-        return json_response(err.messages, status=err.status_code)
+        return json_response(err.messages, status=parser.DEFAULT_VALIDATION_STATUS)
 
 
 @use_args({"value": fields.Int()})
@@ -76,7 +76,7 @@ def always_error(request):
     try:
         return parser.parse(argmap, request)
     except ma.ValidationError as err:
-        return json_response(err.messages, status=err.status_code)
+        return json_response(err.messages, status=parser.DEFAULT_VALIDATION_STATUS)
 
 
 def echo_headers(request):
@@ -112,7 +112,7 @@ class EchoCBV(View):
         try:
             args = parser.parse(hello_args, self.request)
         except ma.ValidationError as err:
-            return json_response(err.messages, status=err.status_code)
+            return json_response(err.messages, status=parser.DEFAULT_VALIDATION_STATUS)
         return json_response(args)
 
     post = get

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -79,17 +79,6 @@ def always_error(request):
         return json_response(err.messages, status=err.status_code)
 
 
-def error400(request):
-    def always_fail(value):
-        raise ValidationError("something went wrong", status_code=400)
-
-    argmap = {"text": fields.Str(validate=always_fail)}
-    try:
-        return parser.parse(argmap, request)
-    except ValidationError as err:
-        return json_response(err.messages, status=err.status_code)
-
-
 def echo_headers(request):
     return json_response(parser.parse(hello_args, request, locations=("headers",)))
 

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -2,7 +2,7 @@ import json
 
 import falcon
 import marshmallow as ma
-from webargs import fields, ValidationError
+from webargs import fields
 from webargs.falconparser import parser, use_args, use_kwargs
 from webargs.core import MARSHMALLOW_VERSION_INFO
 
@@ -87,7 +87,7 @@ class EchoUseKwargsWithPathParam(object):
 class AlwaysError(object):
     def on_get(self, req, resp):
         def always_fail(value):
-            raise ValidationError("something went wrong")
+            raise ma.ValidationError("something went wrong")
 
         args = {"text": fields.Str(validate=always_fail)}
         resp.body = json.dumps(parser.parse(args, req))

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -95,26 +95,6 @@ class AlwaysError(object):
     on_post = on_get
 
 
-class Error400(object):
-    def on_get(self, req, resp):
-        def always_fail(value):
-            raise ValidationError("something went wrong", status_code=400)
-
-        args = {"text": fields.Str(validate=always_fail)}
-        resp.body = json.dumps(parser.parse(args, req))
-
-    on_post = on_get
-
-
-class ErrorInvalid(object):
-    def on_get(self, req, resp):
-        def always_fail(value):
-            raise ValidationError("something went wrong", status_code=12345)
-
-        args = {"text": fields.Str(validate=always_fail)}
-        resp.body = json.dumps(parser.parse(args, req))
-
-
 class EchoHeaders(object):
     def on_get(self, req, resp):
         resp.body = json.dumps(parser.parse(hello_args, req, locations=("headers",)))
@@ -169,11 +149,9 @@ def create_app():
         "/echo_use_kwargs_with_path_param/{name}", EchoUseKwargsWithPathParam()
     )
     app.add_route("/error", AlwaysError())
-    app.add_route("/error400", Error400())
     app.add_route("/echo_headers", EchoHeaders())
     app.add_route("/echo_cookie", EchoCookie())
     app.add_route("/echo_nested", EchoNested())
     app.add_route("/echo_nested_many", EchoNestedMany())
     app.add_route("/echo_use_args_hook", EchoUseArgsHook())
-    app.add_route("/error_invalid", ErrorInvalid())
     return app

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -3,7 +3,7 @@ from flask import Flask, jsonify as J, Response, request
 from flask.views import MethodView
 
 import marshmallow as ma
-from webargs import fields, ValidationError, missing
+from webargs import fields, missing
 from webargs.flaskparser import parser, use_args, use_kwargs
 from webargs.core import MARSHMALLOW_VERSION_INFO
 
@@ -81,7 +81,7 @@ def echo_use_kwargs_with_path(name, value):
 @app.route("/error", methods=["GET", "POST"])
 def error():
     def always_fail(value):
-        raise ValidationError("something went wrong")
+        raise ma.ValidationError("something went wrong")
 
     args = {"text": fields.Str(validate=always_fail)}
     return J(parser.parse(args))

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -87,15 +87,6 @@ def error():
     return J(parser.parse(args))
 
 
-@app.route("/error400", methods=["GET", "POST"])
-def error400():
-    def always_fail(value):
-        raise ValidationError("something went wrong", status_code=400)
-
-    args = {"text": fields.Str(validate=always_fail)}
-    return J(parser.parse(args))
-
-
 @app.route("/echo_headers")
 def echo_headers():
     return J(parser.parse(hello_args, locations=("headers",)))

--- a/tests/apps/pyramid_app.py
+++ b/tests/apps/pyramid_app.py
@@ -66,14 +66,6 @@ def always_error(request):
     return parser.parse(argmap, request)
 
 
-def error400(request):
-    def always_fail(value):
-        raise ValidationError("something went wrong", status_code=400)
-
-    argmap = {"text": fields.Str(validate=always_fail)}
-    return parser.parse(argmap, request)
-
-
 def echo_headers(request):
     return parser.parse(hello_args, request, locations=("headers",))
 
@@ -141,7 +133,6 @@ def create_app():
         echo_use_kwargs_with_path_param,
     )
     add_route(config, "/error", always_error)
-    add_route(config, "/error400", error400)
     add_route(config, "/echo_headers", echo_headers)
     add_route(config, "/echo_cookie", echo_cookie)
     add_route(config, "/echo_file", echo_file)

--- a/tests/apps/pyramid_app.py
+++ b/tests/apps/pyramid_app.py
@@ -1,7 +1,7 @@
 from pyramid.config import Configurator
 import marshmallow as ma
 
-from webargs import fields, ValidationError
+from webargs import fields
 from webargs.pyramidparser import parser, use_args, use_kwargs
 from webargs.core import MARSHMALLOW_VERSION_INFO
 
@@ -60,7 +60,7 @@ def echo_use_kwargs_with_path_param(request, value):
 
 def always_error(request):
     def always_fail(value):
-        raise ValidationError("something went wrong")
+        raise ma.ValidationError("something went wrong")
 
     argmap = {"text": fields.Str(validate=always_fail)}
     return parser.parse(argmap, request)

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -15,10 +15,3 @@ class TestFalconParser(CommonTestCase):
 
     def test_use_args_hook(self, testapp):
         assert testapp.get("/echo_use_args_hook?name=Fred").json == {"name": "Fred"}
-
-    def test_raises_lookup_error_if_invalid_code_is_passed_to_validation_error(
-        self, testapp
-    ):
-        with pytest.raises(LookupError) as excinfo:
-            testapp.get("/error_invalid?text=foo")
-        assert excinfo.value.args[0] == "Status code 12345 not supported"

--- a/tests/test_py3/test_aiohttpparser.py
+++ b/tests/test_py3/test_aiohttpparser.py
@@ -36,10 +36,6 @@ class TestAIOHTTPParser(CommonTestCase):
         assert testapp.get("/echo_method_view").json == {"name": "World"}
         assert testapp.get("/echo_method_view?name=Steve").json == {"name": "Steve"}
 
-    def test_invalid_status_code_passed_to_validation_error(self, testapp):
-        res = testapp.get("/error_invalid?text=foo", expect_errors=True)
-        assert res.status_code == 500
-
     # regression test for https://github.com/marshmallow-code/webargs/issues/165
     def test_multiple_args(self, testapp):
         res = testapp.post_json(

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -10,6 +10,8 @@ except ImportError:
 import mock
 import pytest
 
+import marshmallow as ma
+
 import tornado.web
 import tornado.httputil
 import tornado.httpserver
@@ -18,7 +20,7 @@ import tornado.concurrent
 import tornado.ioloop
 from tornado.testing import AsyncHTTPTestCase
 
-from webargs import fields, missing, ValidationError
+from webargs import fields, missing
 from webargs.tornadoparser import parser, use_args, use_kwargs, get_value
 from webargs.core import parse_json
 
@@ -580,7 +582,7 @@ class ValidateHandler(tornado.web.RequestHandler):
 
 
 def always_fail(val):
-    raise ValidationError("something went wrong")
+    raise ma.ValidationError("something went wrong")
 
 
 class AlwaysFailHandler(tornado.web.RequestHandler):

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -591,23 +591,10 @@ class AlwaysFailHandler(tornado.web.RequestHandler):
         self.write(args)
 
 
-def always_fail_with_400(val):
-    raise ValidationError("something went wrong", status_code=400)
-
-
-class AlwaysFailWith400Handler(tornado.web.RequestHandler):
-    ARGS = {"name": fields.Str(validate=always_fail_with_400)}
-
-    @use_args(ARGS)
-    def post(self, args):
-        self.write(args)
-
-
 validate_app = tornado.web.Application(
     [
         (r"/echo", ValidateHandler),
         (r"/alwaysfail", AlwaysFailHandler),
-        (r"/alwaysfailwith400", AlwaysFailWith400Handler),
     ]
 )
 
@@ -643,15 +630,6 @@ class TestValidateApp(AsyncHTTPTestCase):
             body=json.dumps({"name": "Steve"}),
         )
         assert res.code == 422
-
-    def test_user_validator_with_status_code(self):
-        res = self.fetch(
-            "/alwaysfailwith400",
-            method="POST",
-            headers={"Content-Type": "application/json"},
-            body=json.dumps({"name": "Steve"}),
-        )
-        assert res.code == 400
 
     def test_use_kwargs_with_error(self):
         res = self.fetch("/echo", method="GET")

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -594,10 +594,7 @@ class AlwaysFailHandler(tornado.web.RequestHandler):
 
 
 validate_app = tornado.web.Application(
-    [
-        (r"/echo", ValidateHandler),
-        (r"/alwaysfail", AlwaysFailHandler),
-    ]
+    [(r"/echo", ValidateHandler), (r"/alwaysfail", AlwaysFailHandler)]
 )
 
 

--- a/tests/test_webapp2parser.py
+++ b/tests/test_webapp2parser.py
@@ -7,8 +7,7 @@ except ImportError:  # PY2
 import json
 
 import pytest
-from marshmallow import fields
-from webargs import ValidationError
+from marshmallow import fields, ValidationError
 
 import webtest
 import webapp2

--- a/webargs/__init__.py
+++ b/webargs/__init__.py
@@ -4,7 +4,7 @@ from marshmallow.utils import missing
 # Make marshmallow's validation functions importable from webargs
 from marshmallow import validate
 
-from webargs.core import argmap2schema, WebargsError, ValidationError
+from webargs.core import argmap2schema, ValidationError
 from webargs import fields
 
 __version__ = "4.3.0"
@@ -12,11 +12,4 @@ __author__ = "Steven Loria"
 __license__ = "MIT"
 
 
-__all__ = (
-    "argmap2schema",
-    "WebargsError",
-    "ValidationError",
-    "fields",
-    "missing",
-    "validate",
-)
+__all__ = ("argmap2schema", "ValidationError", "fields", "missing", "validate")

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -142,7 +142,9 @@ class AIOHTTPParser(AsyncParser):
 
     def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handle ValidationErrors and return a JSON response of error messages to the client."""
-        error_class = exception_map.get(error_status_code or self.DEFAULT_VALIDATION_STATUS)
+        error_class = exception_map.get(
+            error_status_code or self.DEFAULT_VALIDATION_STATUS
+        )
         if not error_class:
             raise LookupError("No exception for {0}".format(error.status_code))
         headers = error_headers

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -142,10 +142,10 @@ class AIOHTTPParser(AsyncParser):
 
     def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handle ValidationErrors and return a JSON response of error messages to the client."""
-        error_class = exception_map.get(error_status_code or error.status_code)
+        error_class = exception_map.get(error_status_code or self.DEFAULT_VALIDATION_STATUS)
         if not error_class:
             raise LookupError("No exception for {0}".format(error.status_code))
-        headers = error_headers or error.headers
+        headers = error_headers
         raise error_class(
             body=json.dumps(error.messages).encode("utf-8"),
             headers=headers,

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -61,12 +61,9 @@ class BottleParser(core.Parser):
         """Handles errors during parsing. Aborts the current request with a
         400 error.
         """
-        status_code = error_status_code or getattr(
-            error, "status_code", self.DEFAULT_VALIDATION_STATUS
-        )
-        headers = error_headers or getattr(error, "headers", {})
+        status_code = error_status_code or self.DEFAULT_VALIDATION_STATUS
         raise bottle.HTTPError(
-            status=status_code, body=error.messages, headers=headers, exception=error
+            status=status_code, body=error.messages, headers=error_headers, exception=error
         )
 
     def get_default_request(self):

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -63,7 +63,10 @@ class BottleParser(core.Parser):
         """
         status_code = error_status_code or self.DEFAULT_VALIDATION_STATUS
         raise bottle.HTTPError(
-            status=status_code, body=error.messages, headers=error_headers, exception=error
+            status=status_code,
+            body=error.messages,
+            headers=error_headers,
+            exception=error,
         )
 
     def get_default_request(self):

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -14,6 +14,7 @@ except ImportError:
     import json
 
 import marshmallow as ma
+from marshmallow import ValidationError
 from marshmallow.compat import iteritems
 from marshmallow.utils import missing, is_collection
 
@@ -21,7 +22,6 @@ logger = logging.getLogger(__name__)
 
 
 __all__ = [
-    "WebargsError",
     "ValidationError",
     "argmap2schema",
     "is_multiple",
@@ -63,25 +63,6 @@ DEFAULT_VALIDATION_STATUS = 422
 class RemovedInWebargs5Warning(DeprecationWarning):
     pass
 
-
-class WebargsError(Exception):
-    """Base class for all webargs-related errors."""
-
-    pass
-
-
-class ValidationError(WebargsError, ma.exceptions.ValidationError):
-    """Raised when validation fails on user input.
-
-    .. versionchanged:: 5.0.0
-        status_code and headers arguments are removed. This is
-        just a republish from marshmallow ValidationError.
-
-    .. versionchanged:: 4.2.0
-        status_code and headers arguments are deprecated. Pass
-        error_status_code and error_headers to `Parser.parse`,
-        `Parser.use_args`, and `Parser.use_kwargs` instead.
-    """
 
 def _callable_or_raise(obj):
     """Makes sure an object is callable if it is not ``None``. If not
@@ -339,19 +320,6 @@ class Parser(object):
     def _on_validation_error(
         self, error, req, schema, error_status_code, error_headers
     ):
-        if isinstance(error, ma.exceptions.ValidationError) and not isinstance(
-            error, ValidationError
-        ):
-            # Raise a webargs error instead
-            kwargs = {
-                'data': error.data,
-            }
-            if MARSHMALLOW_VERSION_INFO[0] < 3:
-                kwargs["fields"] = error.fields
-                kwargs["field_names"] = error.field_names
-            else:
-                kwargs["field_name"] = error.field_name
-            error = ValidationError(error.messages, **kwargs)
         if self.error_callback:
             if len(get_func_args(self.error_callback)) > 3:
                 self.error_callback(

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -98,9 +98,7 @@ class ValidationError(WebargsError, ma.exceptions.ValidationError):
                 RemovedInWebargs5Warning,
             )
         self.headers = headers
-        ma.exceptions.ValidationError.__init__(
-            self, message, status_code=status_code, headers=headers, **kwargs
-        )
+        ma.exceptions.ValidationError.__init__(self, message, **kwargs)
 
     def __repr__(self):
         return "ValidationError({0!r}, status_code={1}, headers={2})".format(

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -142,7 +142,7 @@ class FalconParser(core.Parser):
 
     def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handles errors during parsing."""
-        status = status_map.get(error_status_code or error.status_code)
+        status = status_map.get(error_status_code or self.DEFAULT_VALIDATION_STATUS)
         if status is None:
             raise LookupError("Status code {0} not supported".format(error.status_code))
         raise HTTPError(status, errors=error.messages, headers=error_headers)

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -97,16 +97,13 @@ class FlaskParser(core.Parser):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 422 error.
         """
-        status_code = error_status_code or getattr(
-            error, "status_code", self.DEFAULT_VALIDATION_STATUS
-        )
-        headers = error_headers or getattr(error, "headers", None)
+        status_code = error_status_code or self.DEFAULT_VALIDATION_STATUS
         abort(
             status_code,
             exc=error,
             messages=error.messages,
             schema=schema,
-            headers=headers,
+            headers=error_headers,
         )
 
     def get_default_request(self):

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -77,7 +77,7 @@ class PyramidParser(core.Parser):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 400 error.
         """
-        status_code = error_status_code or getattr(error, "status_code", 422)
+        status_code = error_status_code or self.DEFAULT_VALIDATION_STATUS
         raise exception_response(
             status_code, detail=text_type(error), headers=error_headers
         )

--- a/webargs/testing.py
+++ b/webargs/testing.py
@@ -12,8 +12,6 @@ import json
 import pytest
 import webtest
 
-from webargs.core import MARSHMALLOW_VERSION_INFO
-
 
 class CommonTestCase(object):
     """Base test class that defines test methods for common functionality across all
@@ -126,14 +124,6 @@ class CommonTestCase(object):
     def test_user_validation_error_returns_422_response_by_default(self, testapp):
         res = testapp.post_json("/error", {"text": "foo"}, expect_errors=True)
         assert res.status_code == 422
-
-    @pytest.mark.skipif(
-        MARSHMALLOW_VERSION_INFO < (2, 7),
-        reason="status_code only works in marshmallow>=2.7",
-    )
-    def test_user_validation_error_with_status_code(self, testapp):
-        res = testapp.post_json("/error400", {"text": "foo"}, expect_errors=True)
-        assert res.status_code == 400
 
     def test_use_args_decorator(self, testapp):
         assert testapp.get("/echo_use_args?name=Fred").json == {"name": "Fred"}

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -118,9 +118,7 @@ class TornadoParser(core.Parser):
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`
         with a 400 error.
         """
-        status_code = error_status_code or getattr(
-            error, "status_code", core.DEFAULT_VALIDATION_STATUS
-        )
+        status_code = error_status_code or self.DEFAULT_VALIDATION_STATUS
         if status_code == 422:
             reason = "Unprocessable Entity"
         else:


### PR DESCRIPTION
Closes #327.

With this change, the naming of `DEFAULT_VALIDATION_STATUS` is a bit improper, but we can leave it as is to avoid breaking stuff everywhere.