### PR TITLE
BUG: create boolean check for location type allowing more options on marshmellow Field

### DIFF
--- a/webargs/core.py
+++ b/webargs/core.py
@@ -270,7 +270,10 @@ class Parser(object):
         """
         location = field.metadata.get("location")
         if location:
-            locations_to_check = self._validated_locations([location])
+            if isinstance(location, tuple) or isinstance(location, list):
+                locations_to_check = self._validated_locations(location)
+            else:
+                locations_to_check = self._validated_locations([location])
         else:
             locations_to_check = self._validated_locations(locations or self.locations)
 


### PR DESCRIPTION
I have the following use-pattern, which involves transmitting an image file in some cases and in others a string as part of a form:

    'args': {"id": fields.Int(required=True), "image": fields.Field(location=('files', 'form'), allow_blank=True)}

This failed since the location input of Field was converted to a list before converting to a set in upon validation, here:

    def _validated_locations(self, locations):
        """Ensure that the given locations argument is valid.

        :raises: ValueError if a given locations includes an invalid location.
        """
        # The set difference between the given locations and the available locations
        # will be the set of invalid locations
        valid_locations = set(self.__location_map__.keys())
        given = set(locations)

 However the commit change permits this and is backwards compatible for regular single item string inputs.