### PR TITLE
Return error response for invalid JSON payloads

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,9 @@ Changelog
 5.0.0 (unreleased)
 ******************
 
-* *Backwards-incompatible*: A ``JSONDecodeError`` is raised when an
-  invalid JSON payload is passed. This allows users to return a proper
-  error message for invalid JSON payloads instead of passing silently
-  (:issue:`329`). Thanks :user:`zedrdave` for reporting.
+* *Backwards-incompatible*: A 400 HTTPError is raised when an
+  invalid JSON payload is passed.  (:issue:`329`). 
+  Thanks :user:`zedrdave` for reporting.
 
 Other changes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,11 @@ Changelog
   error message for invalid JSON payloads instead of passing silently
   (:issue:`329`). Thanks :user:`zedrdave` for reporting.
 
+Other changes:
+
+* `simplejson <https://pypi.org/project/simplejson/>`_ is now a dependency.
+  This ensures consistency of behavior across Python 2 and 3.
+
 4.3.0 (2018-12-30)
 ******************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+5.0.0 (unreleased)
+******************
+
+* *Backwards-incompatible*: A ``JSONDecodeError`` is raised when an
+  invalid JSON payload is passed. This allows users to return a proper
+  error message for invalid JSON payloads instead of passing silently
+  (:issue:`329`). Thanks :user:`zedrdave` for reporting.
+
 4.3.0 (2018-12-30)
 ******************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,8 @@ Changelog
 
 Other changes:
 
-* `simplejson <https://pypi.org/project/simplejson/>`_ is now a dependency.
+* `simplejson <https://pypi.org/project/simplejson/>`_ is now a required
+  dependency on Python 2 (:pr:`334`).
   This ensures consistency of behavior across Python 2 and 3.
 
 4.3.0 (2018-12-30)

--- a/examples/bottle_example.py
+++ b/examples/bottle_example.py
@@ -12,7 +12,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
-import json
+import simplejson as json
 import datetime as dt
 
 from bottle import route, run, error, response, HTTPResponse

--- a/examples/bottle_example.py
+++ b/examples/bottle_example.py
@@ -12,10 +12,9 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
-from webargs.core import json
 import datetime as dt
 
-from bottle import route, run, error, response, HTTPResponse
+from bottle import route, run, error, response
 from webargs import fields, validate
 from webargs.bottleparser import use_args, use_kwargs
 
@@ -59,20 +58,10 @@ def dateadd(value, addend, unit):
 
 
 # Return validation errors as JSON
+@error(400)
 @error(422)
 def error422(err):
     response.content_type = "application/json"
-    return err.body
-
-
-@error(500)
-def handle_500(err):
-    if isinstance(err.exception, json.JSONDecodeError):
-        return HTTPResponse(
-            json.dumps(["Invalid JSON."]),
-            status=400,
-            headers={"Content-Type": "application/json"},
-        )
     return err.body
 
 

--- a/examples/bottle_example.py
+++ b/examples/bottle_example.py
@@ -12,9 +12,10 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
+import json
 import datetime as dt
 
-from bottle import route, run, error, response
+from bottle import route, run, error, response, HTTPResponse
 from webargs import fields, validate
 from webargs.bottleparser import use_args, use_kwargs
 
@@ -61,6 +62,17 @@ def dateadd(value, addend, unit):
 @error(422)
 def error422(err):
     response.content_type = "application/json"
+    return err.body
+
+
+@error(500)
+def handle_500(err):
+    if isinstance(err.exception, json.JSONDecodeError):
+        return HTTPResponse(
+            json.dumps(["Invalid JSON."]),
+            status=400,
+            headers={"Content-Type": "application/json"},
+        )
     return err.body
 
 

--- a/examples/bottle_example.py
+++ b/examples/bottle_example.py
@@ -60,7 +60,7 @@ def dateadd(value, addend, unit):
 # Return validation errors as JSON
 @error(400)
 @error(422)
-def error422(err):
+def handle_error(err):
     response.content_type = "application/json"
     return err.body
 

--- a/examples/bottle_example.py
+++ b/examples/bottle_example.py
@@ -12,7 +12,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
-import simplejson as json
+from webargs.core import json
 import datetime as dt
 
 from bottle import route, run, error, response, HTTPResponse

--- a/examples/falcon_example.py
+++ b/examples/falcon_example.py
@@ -18,7 +18,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
 """
 import datetime as dt
 
-import simplejson as json
+from webargs.core import json
 
 import falcon
 from webargs import fields, validate

--- a/examples/falcon_example.py
+++ b/examples/falcon_example.py
@@ -18,10 +18,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
 """
 import datetime as dt
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import simplejson as json
 
 import falcon
 from webargs import fields, validate

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -12,7 +12,6 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
-from webargs.core import json
 import datetime as dt
 
 from flask import Flask, jsonify
@@ -66,22 +65,12 @@ def dateadd(value, addend, unit):
 @app.errorhandler(422)
 @app.errorhandler(400)
 def handle_validation_error(err):
-    exc = getattr(err, "exc", None)
-    if exc:
-        headers = err.data["headers"]
-        messages = exc.messages
-    else:
-        headers = None
-        messages = ["Invalid request."]
+    headers = err.data.get("headers", None)
+    messages = err.data.get("messages", ["Invalid request."])
     if headers:
         return jsonify({"errors": messages}), err.code, headers
     else:
         return jsonify({"errors": messages}), err.code
-
-
-@app.errorhandler(json.JSONDecodeError)
-def handle_invalid_json(err):
-    return jsonify(["Invalid JSON."]), 400
 
 
 if __name__ == "__main__":

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -64,7 +64,7 @@ def dateadd(value, addend, unit):
 # Return validation errors as JSON
 @app.errorhandler(422)
 @app.errorhandler(400)
-def handle_validation_error(err):
+def handle_error(err):
     headers = err.data.get("headers", None)
     messages = err.data.get("messages", ["Invalid request."])
     if headers:

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -12,6 +12,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
+import json
 import datetime as dt
 
 from flask import Flask, jsonify
@@ -76,6 +77,11 @@ def handle_validation_error(err):
         return jsonify({"errors": messages}), err.code, headers
     else:
         return jsonify({"errors": messages}), err.code
+
+
+@app.errorhandler(json.JSONDecodeError)
+def handle_invalid_json(err):
+    return jsonify(["Invalid JSON."]), 400
 
 
 if __name__ == "__main__":

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -12,7 +12,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
-import json
+import simplejson as json
 import datetime as dt
 
 from flask import Flask, jsonify

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -12,7 +12,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
-import simplejson as json
+from webargs.core import json
 import datetime as dt
 
 from flask import Flask, jsonify

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
+import sys
 import re
 from setuptools import setup, find_packages
 
-INSTALL_REQUIRES = ["marshmallow>=2.15.2", "simplejson"]
+INSTALL_REQUIRES = ["marshmallow>=2.15.2"]
+if sys.version_info[0] < 3:
+    INSTALL_REQUIRES.append("simplejson")
+
 FRAMEWORKS = [
     "Flask>=0.12.2",
     "Django>=1.11.16",
@@ -49,9 +53,6 @@ def find_version(fname):
     return version
 
 
-__version__ = find_version("webargs/__init__.py")
-
-
 def read(fname):
     with open(fname) as fp:
         content = fp.read()
@@ -60,7 +61,7 @@ def read(fname):
 
 setup(
     name="webargs",
-    version=__version__,
+    version=find_version("webargs/__init__.py"),
     description=(
         "A friendly library for parsing and validating HTTP request arguments, "
         "with built-in support for popular web frameworks, including "

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 INSTALL_REQUIRES = ["marshmallow>=2.15.2"]
 if sys.version_info[0] < 3:
-    INSTALL_REQUIRES.append("simplejson")
+    INSTALL_REQUIRES.append("simplejson>=2.1.0")
 
 FRAMEWORKS = [
     "Flask>=0.12.2",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import re
 from setuptools import setup, find_packages
 
-INSTALL_REQUIRES = ["marshmallow>=2.15.2"]
+INSTALL_REQUIRES = ["marshmallow>=2.15.2", "simplejson"]
 FRAMEWORKS = [
     "Flask>=0.12.2",
     "Django>=1.11.16",

--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -1,3 +1,4 @@
+import json
 import asyncio
 
 import aiohttp
@@ -29,7 +30,13 @@ hello_many_schema = HelloSchema(many=True, **strict_kwargs)
 
 
 async def echo(request):
-    parsed = await parser.parse(hello_args, request)
+    try:
+        parsed = await parser.parse(hello_args, request)
+    except json.JSONDecodeError:
+        raise web.HTTPBadRequest(
+            body=json.dumps(["Invalid JSON."]).encode("utf-8"),
+            content_type="application/json",
+        )
     return json_response(parsed)
 
 

--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -1,4 +1,3 @@
-import json
 import asyncio
 
 import aiohttp
@@ -8,7 +7,7 @@ import marshmallow as ma
 
 from webargs import fields
 from webargs.aiohttpparser import parser, use_args, use_kwargs
-from webargs.core import MARSHMALLOW_VERSION_INFO
+from webargs.core import MARSHMALLOW_VERSION_INFO, json
 
 hello_args = {"name": fields.Str(missing="World", validate=lambda n: len(n) >= 3)}
 hello_multiple = {"name": fields.List(fields.Str())}

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 from bottle import Bottle, HTTPResponse, debug, request, response
 
 import marshmallow as ma

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -1,5 +1,5 @@
 import json
-from bottle import Bottle, HTTPResponse, debug, request, response, error
+from bottle import Bottle, HTTPResponse, debug, request, response
 
 import marshmallow as ma
 from webargs import fields
@@ -115,7 +115,18 @@ def echo_nested_many():
     return parser.parse(args)
 
 
-@error(422)
+@app.error(422)
 def handle_422(err):
     response.content_type = "application/json"
+    return err.body
+
+
+@app.error(500)
+def handle_500(err):
+    if isinstance(err.exception, json.JSONDecodeError):
+        return HTTPResponse(
+            json.dumps(["Invalid JSON."]),
+            status=400,
+            headers={"Content-Type": "application/json"},
+        )
     return err.body

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -115,18 +115,8 @@ def echo_nested_many():
     return parser.parse(args)
 
 
+@app.error(400)
 @app.error(422)
 def handle_422(err):
     response.content_type = "application/json"
-    return err.body
-
-
-@app.error(500)
-def handle_500(err):
-    if isinstance(err.exception, json.JSONDecodeError):
-        return HTTPResponse(
-            json.dumps(["Invalid JSON."]),
-            status=400,
-            headers={"Content-Type": "application/json"},
-        )
     return err.body

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -1,4 +1,4 @@
-import simplejson as json
+from webargs.core import json
 from bottle import Bottle, HTTPResponse, debug, request, response
 
 import marshmallow as ma

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -117,6 +117,6 @@ def echo_nested_many():
 
 @app.error(400)
 @app.error(422)
-def handle_422(err):
+def handle_error(err):
     response.content_type = "application/json"
     return err.body

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 from django.http import HttpResponse
 from django.views.generic import View
 

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -28,6 +28,8 @@ def echo(request):
         args = parser.parse(hello_args, request)
     except ma.ValidationError as err:
         return json_response(err.messages, status=parser.DEFAULT_VALIDATION_STATUS)
+    except json.JSONDecodeError:
+        return json_response({"json": ["Invalid JSON body."]}, status=400)
     return json_response(args)
 
 

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -1,4 +1,4 @@
-import simplejson as json
+from webargs.core import json
 from django.http import HttpResponse
 from django.views.generic import View
 

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 
 import falcon
 import marshmallow as ma

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -20,8 +20,13 @@ hello_many_schema = HelloSchema(many=True, **strict_kwargs)
 
 class Echo(object):
     def on_get(self, req, resp):
-        parsed = parser.parse(hello_args, req)
-        resp.body = json.dumps(parsed)
+        try:
+            parsed = parser.parse(hello_args, req)
+        except json.JSONDecodeError:
+            resp.body = json.dumps(["Invalid JSON."])
+            resp.status = falcon.HTTP_400
+        else:
+            resp.body = json.dumps(parsed)
 
     on_post = on_get
 

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -1,4 +1,4 @@
-import simplejson as json
+from webargs.core import json
 
 import falcon
 import marshmallow as ma

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -176,3 +176,8 @@ def echo_use_kwargs_missing(username, password):
 def handle_validation_error(err):
     assert isinstance(err.data["schema"], ma.Schema)
     return J({"errors": err.exc.messages}), err.code
+
+
+@app.errorhandler(json.JSONDecodeError)
+def handle_invalid_json(err):
+    return J(["Invalid JSON."]), 400

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -173,11 +173,8 @@ def echo_use_kwargs_missing(username, password):
 
 # Return validation errors as JSON
 @app.errorhandler(422)
+@app.errorhandler(400)
 def handle_validation_error(err):
-    assert isinstance(err.data["schema"], ma.Schema)
-    return J({"errors": err.exc.messages}), err.code
-
-
-@app.errorhandler(json.JSONDecodeError)
-def handle_invalid_json(err):
-    return J(["Invalid JSON."]), 400
+    if err.code == 422:
+        assert isinstance(err.data["schema"], ma.Schema)
+    return J(err.data["messages"]), err.code

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 from flask import Flask, jsonify as J, Response, request
 from flask.views import MethodView
 

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -1,4 +1,4 @@
-import simplejson as json
+from webargs.core import json
 from flask import Flask, jsonify as J, Response, request
 from flask.views import MethodView
 

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -174,7 +174,7 @@ def echo_use_kwargs_missing(username, password):
 # Return validation errors as JSON
 @app.errorhandler(422)
 @app.errorhandler(400)
-def handle_validation_error(err):
+def handle_error(err):
     if err.code == 422:
         assert isinstance(err.data["schema"], ma.Schema)
     return J(err.data["messages"]), err.code

--- a/tests/apps/pyramid_app.py
+++ b/tests/apps/pyramid_app.py
@@ -1,4 +1,4 @@
-import simplejson as json
+from webargs.core import json
 
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPBadRequest

--- a/tests/apps/pyramid_app.py
+++ b/tests/apps/pyramid_app.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPBadRequest
@@ -25,7 +25,7 @@ def echo(request):
         return parser.parse(hello_args, request)
     except json.JSONDecodeError:
         error = HTTPBadRequest()
-        error.text = json.dumps(["Invalid JSON."])
+        error.body = json.dumps(["Invalid JSON."]).encode("utf-8")
         error.content_type = "application/json"
         raise error
 

--- a/tests/apps/pyramid_app.py
+++ b/tests/apps/pyramid_app.py
@@ -1,4 +1,7 @@
+import json
+
 from pyramid.config import Configurator
+from pyramid.httpexceptions import HTTPBadRequest
 import marshmallow as ma
 
 from webargs import fields
@@ -18,7 +21,13 @@ hello_many_schema = HelloSchema(many=True, **strict_kwargs)
 
 
 def echo(request):
-    return parser.parse(hello_args, request)
+    try:
+        return parser.parse(hello_args, request)
+    except json.JSONDecodeError:
+        error = HTTPBadRequest()
+        error.text = json.dumps(["Invalid JSON."])
+        error.content_type = "application/json"
+        raise error
 
 
 def echo_query(request):

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -15,3 +15,14 @@ class TestFalconParser(CommonTestCase):
 
     def test_use_args_hook(self, testapp):
         assert testapp.get("/echo_use_args_hook?name=Fred").json == {"name": "Fred"}
+
+    # https://github.com/sloria/webargs/issues/329
+    def test_invalid_json(self, testapp):
+        res = testapp.post(
+            "/echo",
+            '{"foo": "bar", }',
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            expect_errors=True,
+        )
+        assert res.status_code == 400
+        assert res.json["errors"] == {"json": ["Invalid JSON body."]}

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -25,7 +25,7 @@ class TestFlaskParser(CommonTestCase):
     def test_parsing_invalid_view_arg(self, testapp):
         res = testapp.get("/echo_view_arg/foo", expect_errors=True)
         assert res.status_code == 422
-        assert res.json == {"errors": {"view_arg": ["Not a valid integer."]}}
+        assert res.json == {"view_arg": ["Not a valid integer."]}
 
     def test_use_args_with_view_args_parsing(self, testapp):
         res = testapp.get("/echo_view_arg_use_args/42")

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import json
 import mock
 
 from werkzeug.exceptions import HTTPException
@@ -9,7 +8,7 @@ import pytest
 from flask import Flask
 from webargs import fields, ValidationError, missing
 from webargs.flaskparser import parser, abort
-from webargs.core import MARSHMALLOW_VERSION_INFO
+from webargs.core import MARSHMALLOW_VERSION_INFO, json
 
 from .apps.flask_app import app
 from webargs.testing import CommonTestCase

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -337,8 +337,11 @@ class TestParse(object):
         request = make_request(
             body='{"foo": 42,}', headers={"Content-Type": "application/json"}
         )
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(tornado.web.HTTPError) as excinfo:
             parser.parse(attrs, request)
+        error = excinfo.value
+        assert error.status_code == 400
+        assert error.messages == {"json": ["Invalid JSON body."]}
 
     def test_it_should_parse_header_arguments(self):
         attrs = {"string": fields.Str(), "integer": fields.List(fields.Int())}

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import json
+import simplejson as json
 
 try:
     from urllib import urlencode  # python2

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import simplejson as json
+from webargs.core import json
 
 try:
     from urllib import urlencode  # python2

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -331,6 +331,15 @@ class TestParse(object):
         assert parsed["integer"] == [1, 2]
         assert parsed["string"] == value
 
+    def test_it_should_raise_when_json_is_invalid(self):
+        attrs = {"foo": fields.Str()}
+
+        request = make_request(
+            body='{"foo": 42,}', headers={"Content-Type": "application/json"}
+        )
+        with pytest.raises(json.JSONDecodeError):
+            parser.parse(attrs, request)
+
     def test_it_should_parse_header_arguments(self):
         attrs = {"string": fields.Str(), "integer": fields.List(fields.Int())}
 

--- a/tests/test_webapp2parser.py
+++ b/tests/test_webapp2parser.py
@@ -4,7 +4,7 @@ try:
     from urllib.parse import urlencode
 except ImportError:  # PY2
     from urllib import urlencode
-import json
+import simplejson as json
 
 import pytest
 from marshmallow import fields, ValidationError

--- a/tests/test_webapp2parser.py
+++ b/tests/test_webapp2parser.py
@@ -61,6 +61,14 @@ def test_parse_json():
     assert parser.parse(hello_args, req=request) == expected
 
 
+def test_parse_invalid_json():
+    request = webapp2.Request.blank(
+        "/echo", POST='{"foo": "bar", }', headers={"content-type": "application/json"}
+    )
+    with pytest.raises(json.JSONDecodeError):
+        parser.parse(hello_args, req=request)
+
+
 def test_parse_json_with_vendor_media_type():
     expected = {"name": "Fred"}
     request = webapp2.Request.blank(

--- a/tests/test_webapp2parser.py
+++ b/tests/test_webapp2parser.py
@@ -4,7 +4,7 @@ try:
     from urllib.parse import urlencode
 except ImportError:  # PY2
     from urllib import urlencode
-import simplejson as json
+from webargs.core import json
 
 import pytest
 from marshmallow import fields, ValidationError

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -23,7 +23,6 @@ Example: ::
     app = web.Application()
     app.router.add_route('GET', '/', index)
 """
-import json
 import warnings
 
 import aiohttp
@@ -31,6 +30,7 @@ from aiohttp import web
 from aiohttp import web_exceptions
 
 from webargs import core
+from webargs.core import json
 from webargs.asyncparser import AsyncParser
 
 AIOHTTP_MAJOR_VERSION = int(aiohttp.__version__.split(".")[0])
@@ -98,7 +98,7 @@ class AIOHTTPParser(AsyncParser):
             if not (req.body_exists and is_json_request(req)):
                 return core.missing
             try:
-                json_data = await req.json()
+                json_data = await req.json(loads=json.loads)
             except json.JSONDecodeError as e:
                 if e.doc == "":
                     return core.missing

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -103,7 +103,7 @@ class AIOHTTPParser(AsyncParser):
                 if e.doc == "":
                     return core.missing
                 else:
-                    raise e
+                    return self.handle_invalid_json_error(e, req)
             self._cache["json"] = json_data
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
@@ -152,6 +152,13 @@ class AIOHTTPParser(AsyncParser):
             body=json.dumps(error.messages).encode("utf-8"),
             headers=headers,
             content_type="application/json",
+        )
+
+    def handle_invalid_json_error(self, error, req, *args, **kwargs):
+        error_class = exception_map.get(400)
+        messages = {"json": ["Invalid JSON body."]}
+        raise error_class(
+            body=json.dumps(messages).encode("utf-8"), content_type="application/json"
         )
 
 

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -17,7 +17,7 @@ Example: ::
     if __name__ == '__main__':
         run(debug=True)
 """
-import json
+import simplejson as json
 import bottle
 
 from webargs import core

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -17,6 +17,7 @@ Example: ::
     if __name__ == '__main__':
         run(debug=True)
 """
+import json
 import bottle
 
 from webargs import core
@@ -39,8 +40,13 @@ class BottleParser(core.Parser):
         if json_data is None:
             try:
                 self._cache["json"] = json_data = req.json
-            except (AttributeError, ValueError):
+            except AttributeError:
                 return core.missing
+            except json.JSONDecodeError as e:
+                if e.doc == "":
+                    return core.missing
+                else:
+                    raise
             if json_data is None:
                 return core.missing
         return core.get_value(json_data, name, field, allow_many_nested=True)

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -46,7 +46,7 @@ class BottleParser(core.Parser):
                 if e.doc == "":
                     return core.missing
                 else:
-                    raise
+                    return self.handle_invalid_json_error(e, req)
             if json_data is None:
                 return core.missing
         return core.get_value(json_data, name, field, allow_many_nested=True)
@@ -73,6 +73,11 @@ class BottleParser(core.Parser):
             body=error.messages,
             headers=error_headers,
             exception=error,
+        )
+
+    def handle_invalid_json_error(self, error, req, *args, **kwargs):
+        raise bottle.HTTPError(
+            status=400, body={"json": ["Invalid JSON body."]}, exception=error
         )
 
     def get_default_request(self):

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -17,10 +17,10 @@ Example: ::
     if __name__ == '__main__':
         run(debug=True)
 """
-import simplejson as json
 import bottle
 
 from webargs import core
+from webargs.core import json
 
 
 class BottleParser(core.Parser):

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -8,7 +8,10 @@ import logging
 import warnings
 from distutils.version import LooseVersion
 
-import simplejson as json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 import marshmallow as ma
 from marshmallow import ValidationError

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -8,10 +8,7 @@ import logging
 import warnings
 from distutils.version import LooseVersion
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import simplejson as json
 
 import marshmallow as ma
 from marshmallow import ValidationError
@@ -169,9 +166,9 @@ def get_value(data, name, field, allow_many_nested=False):
     return val
 
 
-def parse_json(s):
+def parse_json(s, encoding="utf-8"):
     if isinstance(s, bytes):
-        s = s.decode("utf-8")
+        s = s.decode(encoding)
     return json.loads(s)
 
 

--- a/webargs/djangoparser.py
+++ b/webargs/djangoparser.py
@@ -46,8 +46,13 @@ class DjangoParser(core.Parser):
         """Pull a json value from the request body."""
         try:
             json_data = json.loads(req.body.decode("utf-8"))
-        except (AttributeError, ValueError):
+        except AttributeError:
             return core.missing
+        except json.JSONDecodeError as e:
+            if e.doc == "":
+                return core.missing
+            else:
+                raise
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_cookies(self, req, name, field):

--- a/webargs/djangoparser.py
+++ b/webargs/djangoparser.py
@@ -18,9 +18,8 @@ Example usage: ::
         def get(self, args, request):
             return HttpResponse('Hello ' + args['name'])
 """
-import simplejson as json
-
 from webargs import core
+from webargs.core import json
 
 
 class DjangoParser(core.Parser):

--- a/webargs/djangoparser.py
+++ b/webargs/djangoparser.py
@@ -18,7 +18,7 @@ Example usage: ::
         def get(self, args, request):
             return HttpResponse('Hello ' + args['name'])
 """
-import json
+import simplejson as json
 
 from webargs import core
 
@@ -44,15 +44,17 @@ class DjangoParser(core.Parser):
 
     def parse_json(self, req, name, field):
         """Pull a json value from the request body."""
-        try:
-            json_data = json.loads(req.body.decode("utf-8"))
-        except AttributeError:
-            return core.missing
-        except json.JSONDecodeError as e:
-            if e.doc == "":
+        json_data = self._cache.get("json")
+        if json_data is None:
+            try:
+                self._cache["json"] = json_data = core.parse_json(req.body)
+            except AttributeError:
                 return core.missing
-            else:
-                raise
+            except json.JSONDecodeError as e:
+                if e.doc == "":
+                    return core.missing
+                else:
+                    raise
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_cookies(self, req, name, field):

--- a/webargs/djangoparser.py
+++ b/webargs/djangoparser.py
@@ -53,7 +53,7 @@ class DjangoParser(core.Parser):
                 if e.doc == "":
                     return core.missing
                 else:
-                    raise
+                    return self.handle_invalid_json_error(e, req)
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_cookies(self, req, name, field):
@@ -75,6 +75,9 @@ class DjangoParser(core.Parser):
             return args[0].request
         except AttributeError:  # first arg is request
             return args[0]
+
+    def handle_invalid_json_error(self, error, req, *args, **kwargs):
+        raise error
 
 
 parser = DjangoParser()

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -116,7 +116,10 @@ class FalconParser(core.Parser):
         """
         json_data = self._cache.get("json_data")
         if json_data is None:
-            self._cache["json_data"] = json_data = parse_json_body(req)
+            try:
+                self._cache["json_data"] = json_data = parse_json_body(req)
+            except json.JSONDecodeError as e:
+                return self.handle_invalid_json_error(e, req)
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_headers(self, req, name, field):
@@ -150,6 +153,11 @@ class FalconParser(core.Parser):
         if status is None:
             raise LookupError("Status code {0} not supported".format(error.status_code))
         raise HTTPError(status, errors=error.messages, headers=error_headers)
+
+    def handle_invalid_json_error(self, error, req, *args, **kwargs):
+        status = status_map.get(400)
+        messages = {"json": ["Invalid JSON body."]}
+        raise HTTPError(status, errors=messages)
 
 
 parser = FalconParser()

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """Falcon request argument parsing module.
 """
+import json
+
 import falcon
+from falcon.util.uri import parse_query_string
 
 from webargs import core
-from falcon.util.uri import parse_query_string
 
 HTTP_422 = "422 Unprocessable Entity"
 
@@ -38,8 +40,11 @@ def parse_json_body(req):
         if body:
             try:
                 return core.parse_json(body)
-            except (TypeError, ValueError):
-                pass
+            except json.JSONDecodeError as e:
+                if e.doc == "":
+                    return core.missing
+                else:
+                    raise
     return {}
 
 

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Falcon request argument parsing module.
 """
-import json
+import simplejson as json
 
 import falcon
 from falcon.util.uri import parse_query_string

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """Falcon request argument parsing module.
 """
-import simplejson as json
-
 import falcon
 from falcon.util.uri import parse_query_string
 
 from webargs import core
+from webargs.core import json
 
 HTTP_422 = "422 Unprocessable Entity"
 

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -67,7 +67,7 @@ class FlaskParser(core.Parser):
                 if e.doc == "":
                     return core.missing
                 else:
-                    raise
+                    return self.handle_invalid_json_error(e, req)
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):
@@ -106,6 +106,9 @@ class FlaskParser(core.Parser):
             schema=schema,
             headers=error_headers,
         )
+
+    def handle_invalid_json_error(self, error, req, *args, **kwargs):
+        abort(400, exc=error, messages={"json": ["Invalid JSON body."]})
 
     def get_default_request(self):
         """Override to use Flask's thread-local request objec by default"""

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -19,12 +19,11 @@ Example: ::
     def index(args):
         return 'Hello ' + args['name']
 """
-import simplejson as json
-
 import flask
 from werkzeug.exceptions import HTTPException
 
 from webargs import core
+from webargs.core import json
 
 
 def abort(http_status_code, exc=None, **kwargs):

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -19,10 +19,9 @@ Example: ::
     def index(args):
         return 'Hello ' + args['name']
 """
-import json
+import simplejson as json
 
 import flask
-from flask import json as flask_json
 from werkzeug.exceptions import HTTPException
 
 from webargs import core
@@ -64,7 +63,7 @@ class FlaskParser(core.Parser):
             # JSONDecodeErrors consistently
             data = req._get_data_for_json(cache=True)
             try:
-                self._cache["json"] = json_data = flask_json.loads(data)
+                self._cache["json"] = json_data = core.parse_json(data)
             except json.JSONDecodeError as e:
                 if e.doc == "":
                     return core.missing

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -25,7 +25,6 @@ Example usage: ::
         server = make_server('0.0.0.0', 6543, app)
         server.serve_forever()
 """
-import simplejson as json
 import collections
 import functools
 
@@ -34,6 +33,7 @@ from pyramid.httpexceptions import exception_response
 
 from marshmallow.compat import text_type
 from webargs import core
+from webargs.core import json
 
 
 class PyramidParser(core.Parser):

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -25,6 +25,7 @@ Example usage: ::
         server = make_server('0.0.0.0', 6543, app)
         server.serve_forever()
 """
+import json
 import collections
 import functools
 
@@ -52,8 +53,11 @@ class PyramidParser(core.Parser):
         """Pull a json value from the request."""
         try:
             json_data = req.json_body
-        except ValueError:
-            return core.missing
+        except json.JSONDecodeError as e:
+            if e.doc == "":
+                return core.missing
+            else:
+                raise
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_cookies(self, req, name, field):

--- a/webargs/testing.py
+++ b/webargs/testing.py
@@ -204,4 +204,4 @@ class CommonTestCase(object):
             expect_errors=True,
         )
         assert res.status_code == 400
-        assert res.json == ["Invalid JSON."]
+        assert res.json == {"json": ["Invalid JSON body."]}

--- a/webargs/testing.py
+++ b/webargs/testing.py
@@ -184,3 +184,24 @@ class CommonTestCase(object):
             "/echo_file", {"myfile": webtest.Upload("README.rst", b"data")}
         )
         assert res.json == {"myfile": "data"}
+
+    # https://github.com/sloria/webargs/pull/297
+    def test_empty_json(self, testapp):
+        res = testapp.post(
+            "/echo",
+            "",
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+        )
+        assert res.status_code == 200
+        assert res.json == {"name": "World"}
+
+    # https://github.com/sloria/webargs/issues/329
+    def test_invalid_json(self, testapp):
+        res = testapp.post(
+            "/echo",
+            '{"foo": "bar", }',
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            expect_errors=True,
+        )
+        assert res.status_code == 400
+        assert res.json == ["Invalid JSON."]

--- a/webargs/testing.py
+++ b/webargs/testing.py
@@ -7,10 +7,10 @@ for testing parsers.
     Methods and functions in this module may change without
     warning and without a major version change.
 """
-import json
-
 import pytest
 import webtest
+
+from webargs.core import json
 
 
 class CommonTestCase(object):

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -90,7 +90,10 @@ class TornadoParser(core.Parser):
         """Pull a json value from the request."""
         json_data = self._cache.get("json")
         if json_data is None:
-            self._cache["json"] = json_data = parse_json_body(req)
+            try:
+                self._cache["json"] = json_data = parse_json_body(req)
+            except json.JSONDecodeError as e:
+                return self.handle_invalid_json_error(e, req)
             if json_data is None:
                 return core.missing
         return core.get_value(json_data, name, field, allow_many_nested=True)
@@ -135,6 +138,14 @@ class TornadoParser(core.Parser):
             reason=reason,
             messages=error.messages,
             headers=error_headers,
+        )
+
+    def handle_invalid_json_error(self, error, req, *args, **kwargs):
+        raise HTTPError(
+            400,
+            log_message="Invalid JSON body.",
+            reason="Bad Request",
+            messages={"json": ["Invalid JSON body."]},
         )
 
     def get_request_from_view_args(self, view, args, kwargs):

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -14,12 +14,12 @@ Example: ::
             response = {'message': 'Hello {}'.format(args['name'])}
             self.write(response)
 """
-import simplejson as json
 import tornado.web
 from tornado.escape import _unicode
 
 from marshmallow.compat import basestring
 from webargs import core
+from webargs.core import json
 
 
 class HTTPError(tornado.web.HTTPError):

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -14,6 +14,7 @@ Example: ::
             response = {'message': 'Hello {}'.format(args['name'])}
             self.write(response)
 """
+import json
 import tornado.web
 from tornado.escape import _unicode
 
@@ -36,8 +37,13 @@ def parse_json_body(req):
     if content_type and core.is_json(content_type):
         try:
             return core.parse_json(req.body)
-        except (TypeError, ValueError):
+        except TypeError:
             pass
+        except json.JSONDecodeError as e:
+            if e.doc == "":
+                return core.missing
+            else:
+                raise
     return {}
 
 

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -14,7 +14,7 @@ Example: ::
             response = {'message': 'Hello {}'.format(args['name'])}
             self.write(response)
 """
-import json
+import simplejson as json
 import tornado.web
 from tornado.escape import _unicode
 

--- a/webargs/webapp2parser.py
+++ b/webargs/webapp2parser.py
@@ -27,10 +27,11 @@ Example: ::
         webapp2.Route(r'/hello_dict', MainPage, handler_method='get_kwargs'),
     ], debug=True)
 """
-import simplejson as json
-from webargs import core
 import webapp2
 import webob.multidict
+
+from webargs import core
+from webargs.core import json
 
 
 class Webapp2Parser(core.Parser):

--- a/webargs/webapp2parser.py
+++ b/webargs/webapp2parser.py
@@ -27,6 +27,7 @@ Example: ::
         webapp2.Route(r'/hello_dict', MainPage, handler_method='get_kwargs'),
     ], debug=True)
 """
+import json
 from webargs import core
 import webapp2
 import webapp2_extras.json
@@ -40,8 +41,11 @@ class Webapp2Parser(core.Parser):
         """Pull a json value from the request."""
         try:
             json_data = webapp2_extras.json.decode(req.body)
-        except ValueError:
-            return core.missing
+        except json.JSONDecodeError as e:
+            if e.doc == "":
+                return core.missing
+            else:
+                raise
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):

--- a/webargs/webapp2parser.py
+++ b/webargs/webapp2parser.py
@@ -27,10 +27,9 @@ Example: ::
         webapp2.Route(r'/hello_dict', MainPage, handler_method='get_kwargs'),
     ], debug=True)
 """
-import json
+import simplejson as json
 from webargs import core
 import webapp2
-import webapp2_extras.json
 import webob.multidict
 
 
@@ -39,13 +38,15 @@ class Webapp2Parser(core.Parser):
 
     def parse_json(self, req, name, field):
         """Pull a json value from the request."""
-        try:
-            json_data = webapp2_extras.json.decode(req.body)
-        except json.JSONDecodeError as e:
-            if e.doc == "":
-                return core.missing
-            else:
-                raise
+        json_data = self._cache.get("json")
+        if json_data is None:
+            try:
+                self._cache["json"] = json_data = core.parse_json(req.body)
+            except json.JSONDecodeError as e:
+                if e.doc == "":
+                    return core.missing
+                else:
+                    raise
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):


### PR DESCRIPTION
Previously, invalid JSON payloads were allowed to pass silently.
With this change, a HTTPError with status code 400 and a payload of `{"json": ["Invalid JSON body."]}` is raised instead.

close #329

Note: Adds simplejson as a dependency on Python 2.