### PR TITLE
Deprecate status_code and headers params of ValidationErrors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,53 @@ Features:
 
 * Add ``force_all`` argument to ``use_args`` and ``use_kwargs``
   (:issue:`252`, :issue:`307`). Thanks :user:`piroux` for reporting.
+* The ``status_code`` and ``headers`` arguments to ``ValidationError``
+  are deprecated. Pass ``error_status_code`` and ``error_headers`` to
+  `Parser.parse`, `Parser.use_args`, and `Parser.use_kwargs` instead.
+  (:issue:`327`, :issue:`336`).
+* Custom error handlers receive ``error_status_code`` and ``error_headers`` arguments.
+  (:issue:`327`).
+
+.. code-block:: python
+
+    # <4.2.0
+    @parser.error_handler
+    def handle_error(error, req, schema):
+        raise CustomError(error.messages)
+
+
+    class MyParser(FlaskParser):
+        def handle_error(self, error, req, schema):
+            # ...
+            raise CustomError(error.messages)
+
+
+    # >=4.2.0
+    @parser.error_handler
+    def handle_error(error, req, schema, status_code, headers):
+        raise CustomError(error.messages)
+
+
+    # OR
+
+
+    @parser.error_handler
+    def handle_error(error, **kwargs):
+        raise CustomError(error.messages)
+
+
+    class MyParser(FlaskParser):
+        def handle_error(self, error, req, schema, status_code, headers):
+            # ...
+            raise CustomError(error.messages)
+
+        # OR
+
+        def handle_error(self, error, req, **kwargs):
+            # ...
+            raise CustomError(error.messages)
+
+Legacy error handlers will be supported until version 5.0.0.
 
 4.1.3 (2018-12-02)
 ******************

--- a/docs/framework_support.rst
+++ b/docs/framework_support.rst
@@ -32,7 +32,7 @@ Error Handling
 ++++++++++++++
 
 Webargs uses Flask's ``abort`` function to raise an ``HTTPException`` when a validation error occurs.
-If you use the ``Flask.errorhandler`` method to handle errors, you can access validation messages from the ``messages`` attribute of 
+If you use the ``Flask.errorhandler`` method to handle errors, you can access validation messages from the ``messages`` attribute of
 the attached ``ValidationError``.
 
 Here is an example error handler that returns validation messages to the client as JSON.
@@ -41,16 +41,20 @@ Here is an example error handler that returns validation messages to the client 
 
     from flask import jsonify
 
-
+    # Return validation errors as JSON
     @app.errorhandler(422)
-    def handle_invalid_requests(err):
+    def handle_validation_error(err):
         exc = getattr(err, "exc", None)
         if exc:
-            # Get validation messages from the ValidationError object
+            headers = err.data["headers"]
             messages = exc.messages
         else:
-            messages = ["Invalid request"]
-        return jsonify({"messages": messages}), err.code
+            headers = None
+            messages = ["Invalid request."]
+        if headers:
+            return jsonify({"errors": messages}), err.code, headers
+        else:
+            return jsonify({"errors": messages}), err.code
 
 URL Matches
 +++++++++++

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -200,7 +200,7 @@ Then decorate that function with :func:`Parser.error_handler <webargs.core.Parse
 
 
     @parser.error_handler
-    def handle_error(error, req, schema):
+    def handle_error(error, req, schema, status_code, headers):
         raise CustomError(error.messages)
 
 Nesting Fields

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -150,21 +150,6 @@ The validator may return either a `boolean` or raise a :exc:`ValidationError <we
 
     You may pass a list of validators to the ``validate`` parameter.
 
-.. note::
-
-    You may pass an HTTP status code to `ValidationError <webargs.core.ValidationError>`.
-
-    .. code-block:: python
-    
-        def must_exist_in_db(val):
-            if not User.query.get(val):
-                # Optionally pass a status_code
-                raise ValidationError('User does not exist', status_code=404)
-
-        argmap = {
-            'id': fields.Int(validate=must_exist_in_db)
-        }
-
 The full arguments dictionary can also be validated by passing ``validate`` to :meth:`Parser.parse <webargs.core.Parser.parse>`, :meth:`Parser.use_args <webargs.core.Parser.use_args>`, :meth:`Parser.use_kwargs <webargs.core.Parser.use_kwargs>`.
 
 

--- a/examples/annotations_example.py
+++ b/examples/annotations_example.py
@@ -73,9 +73,19 @@ def user_detail(user_id, name: fields.Str(required=True)) -> UserSchema():  # no
 
 # Return validation errors as JSON
 @app.errorhandler(422)
+@app.errorhandler(400)
 def handle_validation_error(err):
-    exc = err.exc
-    return jsonify({"errors": exc.messages}), 422
+    exc = getattr(err, "exc", None)
+    if exc:
+        headers = err.data["headers"]
+        messages = exc.messages
+    else:
+        headers = None
+        messages = ["Invalid request."]
+    if headers:
+        return jsonify({"errors": messages}), err.code, headers
+    else:
+        return jsonify({"errors": messages}), err.code
 
 
 if __name__ == "__main__":

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -35,7 +35,7 @@ add_args = {"x": fields.Float(required=True), "y": fields.Float(required=True)}
 
 
 @app.route("/add", methods=["POST"])
-@use_kwargs(add_args)
+@use_kwargs(add_args, error_status_code=400)
 def add(x, y):
     """An addition endpoint."""
     return jsonify({"result": x + y})
@@ -63,6 +63,7 @@ def dateadd(value, addend, unit):
 
 # Return validation errors as JSON
 @app.errorhandler(422)
+@app.errorhandler(400)
 def handle_validation_error(err):
     exc = getattr(err, "exc", None)
     if exc:

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -35,7 +35,7 @@ add_args = {"x": fields.Float(required=True), "y": fields.Float(required=True)}
 
 
 @app.route("/add", methods=["POST"])
-@use_kwargs(add_args, error_status_code=400)
+@use_kwargs(add_args)
 def add(x, y):
     """An addition endpoint."""
     return jsonify({"result": x + y})
@@ -67,11 +67,15 @@ def dateadd(value, addend, unit):
 def handle_validation_error(err):
     exc = getattr(err, "exc", None)
     if exc:
-        # Get validation messages from the ValidationError object
+        headers = err.data["headers"]
         messages = exc.messages
     else:
-        messages = ["Invalid request"]
-    return jsonify({"messages": messages}), err.code
+        headers = None
+        messages = ["Invalid request."]
+    if headers:
+        return jsonify({"errors": messages}), err.code, headers
+    else:
+        return jsonify({"errors": messages}), err.code
 
 
 if __name__ == "__main__":

--- a/examples/flaskrestful_example.py
+++ b/examples/flaskrestful_example.py
@@ -70,11 +70,11 @@ class DateAddResource(Resource):
 
 # This error handler is necessary for usage with Flask-RESTful
 @parser.error_handler
-def handle_request_parsing_error(err, req, schema):
+def handle_request_parsing_error(err, req, schema, error_status_code, error_headers):
     """webargs error handler that uses Flask-RESTful's abort function to return
     a JSON error response to the client.
     """
-    abort(422, errors=err.messages)
+    abort(error_status_code, errors=err.messages)
 
 
 if __name__ == "__main__":

--- a/examples/pyramid_example.py
+++ b/examples/pyramid_example.py
@@ -76,5 +76,7 @@ if __name__ == "__main__":
     config.add_route("dateadd", "/dateadd")
     config.scan(__name__)
     app = config.make_wsgi_app()
-    server = make_server("0.0.0.0", 5001, app)
+    port = 5001
+    server = make_server("0.0.0.0", port, app)
+    print("Serving on port {}".format(port))
     server.serve_forever()

--- a/examples/schema_example.py
+++ b/examples/schema_example.py
@@ -124,9 +124,19 @@ def user_list(reqargs, limit):
 
 # Return validation errors as JSON
 @app.errorhandler(422)
+@app.errorhandler(400)
 def handle_validation_error(err):
-    exc = err.data["exc"]
-    return jsonify({"errors": exc.messages}), 422
+    exc = getattr(err, "exc", None)
+    if exc:
+        headers = err.data["headers"]
+        messages = exc.messages
+    else:
+        headers = None
+        messages = ["Invalid request."]
+    if headers:
+        return jsonify({"errors": messages}), err.code, headers
+    else:
+        return jsonify({"errors": messages}), err.code
 
 
 if __name__ == "__main__":

--- a/examples/tornado_example.py
+++ b/examples/tornado_example.py
@@ -28,6 +28,9 @@ class BaseRequestHandler(RequestHandler):
             etype, exc, traceback = kwargs["exc_info"]
             if hasattr(exc, "messages"):
                 self.write({"errors": exc.messages})
+                if getattr(exc, "headers", None):
+                    for name, val in exc.headers.items():
+                        self.set_header(name, val)
                 self.finish()
 
 
@@ -80,5 +83,7 @@ if __name__ == "__main__":
         [(r"/", HelloHandler), (r"/add", AdderHandler), (r"/dateadd", DateAddHandler)],
         debug=True,
     )
-    app.listen(5001)
+    port = 5001
+    app.listen(port)
+    print("Serving on port {}".format(port))
     tornado.ioloop.IOLoop.instance().start()

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -184,4 +184,4 @@ def echo_use_kwargs_missing(username, password):
 @app.errorhandler(422)
 def handle_validation_error(err):
     assert isinstance(err.data["schema"], ma.Schema)
-    return J({"errors": err.exc.messages}), 422
+    return J({"errors": err.exc.messages}), err.code

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -140,9 +140,9 @@ class AIOHTTPParser(AsyncParser):
         assert isinstance(req, web.Request), "Request argument not found for handler"
         return req
 
-    def handle_error(self, error, req, schema):
+    def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handle ValidationErrors and return a JSON response of error messages to the client."""
-        error_class = exception_map.get(error.status_code)
+        error_class = exception_map.get(error_status_code or error.status_code)
         if not error_class:
             raise LookupError("No exception for {0}".format(error.status_code))
         raise error_class(

--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -145,8 +145,10 @@ class AIOHTTPParser(AsyncParser):
         error_class = exception_map.get(error_status_code or error.status_code)
         if not error_class:
             raise LookupError("No exception for {0}".format(error.status_code))
+        headers = error_headers or error.headers
         raise error_class(
             body=json.dumps(error.messages).encode("utf-8"),
+            headers=headers,
             content_type="application/json",
         )
 

--- a/webargs/asyncparser.py
+++ b/webargs/asyncparser.py
@@ -57,7 +57,14 @@ class AsyncParser(core.Parser):
 
     # TODO: Lots of duplication from core.Parser here. Rethink.
     async def parse(
-        self, argmap, req=None, locations=None, validate=None, force_all=False
+        self,
+        argmap,
+        req=None,
+        locations=None,
+        validate=None,
+        force_all=False,
+        error_status_code=None,
+        error_headers=None,
     ):
         """Coroutine variant of `webargs.core.Parser`.
 
@@ -76,7 +83,9 @@ class AsyncParser(core.Parser):
             data = result.data if core.MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:
-            self._on_validation_error(error, req, schema)
+            self._on_validation_error(
+                error, req, schema, error_status_code, error_headers
+            )
         finally:
             self.clear_cache()
         if force_all:
@@ -91,6 +100,8 @@ class AsyncParser(core.Parser):
         as_kwargs=False,
         validate=None,
         force_all=None,
+        error_status_code=None,
+        error_headers=None,
     ):
         """Decorator that injects parsed arguments into a view function or method.
 
@@ -122,6 +133,8 @@ class AsyncParser(core.Parser):
                         locations=locations,
                         validate=validate,
                         force_all=force_all_,
+                        error_status_code=error_status_code,
+                        error_headers=error_headers,
                     )
                     if as_kwargs:
                         kwargs.update(parsed_args)
@@ -146,6 +159,8 @@ class AsyncParser(core.Parser):
                         locations=locations,
                         validate=validate,
                         force_all=force_all_,
+                        error_status_code=error_status_code,
+                        error_headers=error_headers,
                     )
                     if as_kwargs:
                         kwargs.update(parsed_args)

--- a/webargs/bottleparser.py
+++ b/webargs/bottleparser.py
@@ -57,12 +57,14 @@ class BottleParser(core.Parser):
         """Pull a file from the request."""
         return core.get_value(req.files, name, field)
 
-    def handle_error(self, error, req, schema):
+    def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handles errors during parsing. Aborts the current request with a
         400 error.
         """
-        status_code = getattr(error, "status_code", self.DEFAULT_VALIDATION_STATUS)
-        headers = getattr(error, "headers", {})
+        status_code = error_status_code or getattr(
+            error, "status_code", self.DEFAULT_VALIDATION_STATUS
+        )
+        headers = error_headers or getattr(error, "headers", {})
         raise bottle.HTTPError(
             status=status_code, body=error.messages, headers=headers, exception=error
         )

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -537,6 +537,10 @@ class Parser(object):
             in the parsed arguments dictionary with the ``missing`` value.
             If `False`, missing values will be omitted. If `None`, fall back
             to the value of ``as_kwargs``.
+        :param int error_status_code: Status code passed to error handler functions when
+            a `ValidationError` is raised.
+        :param dict error_headers: Headers passed to error handler functions when a
+            a `ValidationError` is raised.
         """
         locations = locations or self.locations
         request_obj = req

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -142,10 +142,10 @@ class FalconParser(core.Parser):
 
     def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handles errors during parsing."""
-        status = error_status_code or status_map.get(error.status_code)
+        status = status_map.get(error_status_code or error.status_code)
         if status is None:
             raise LookupError("Status code {0} not supported".format(error.status_code))
-        raise HTTPError(status, errors=error.messages)
+        raise HTTPError(status, errors=error.messages, headers=error_headers)
 
 
 parser = FalconParser()

--- a/webargs/falconparser.py
+++ b/webargs/falconparser.py
@@ -140,9 +140,9 @@ class FalconParser(core.Parser):
             "Parsing files not yet supported by {0}".format(self.__class__.__name__)
         )
 
-    def handle_error(self, error, req, schema):
+    def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handles errors during parsing."""
-        status = status_map.get(error.status_code)
+        status = error_status_code or status_map.get(error.status_code)
         if status is None:
             raise LookupError("Status code {0} not supported".format(error.status_code))
         raise HTTPError(status, errors=error.messages)

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -100,7 +100,14 @@ class FlaskParser(core.Parser):
         status_code = error_status_code or getattr(
             error, "status_code", self.DEFAULT_VALIDATION_STATUS
         )
-        abort(status_code, exc=error, messages=error.messages, schema=schema)
+        headers = error_headers or getattr(error, "headers", None)
+        abort(
+            status_code,
+            exc=error,
+            messages=error.messages,
+            schema=schema,
+            headers=headers,
+        )
 
     def get_default_request(self):
         """Override to use Flask's thread-local request objec by default"""

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -93,11 +93,13 @@ class FlaskParser(core.Parser):
         """Pull a file from the request."""
         return core.get_value(req.files, name, field)
 
-    def handle_error(self, error, req, schema):
+    def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 422 error.
         """
-        status_code = getattr(error, "status_code", self.DEFAULT_VALIDATION_STATUS)
+        status_code = error_status_code or getattr(
+            error, "status_code", self.DEFAULT_VALIDATION_STATUS
+        )
         abort(status_code, exc=error, messages=error.messages, schema=schema)
 
     def get_default_request(self):

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -73,11 +73,11 @@ class PyramidParser(core.Parser):
         """Pull a value from the request's `matchdict`."""
         return core.get_value(req.matchdict, name, field)
 
-    def handle_error(self, error, req, schema):
+    def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handles errors during parsing. Aborts the current HTTP request and
         responds with a 400 error.
         """
-        status_code = getattr(error, "status_code", 422)
+        status_code = error_status_code or getattr(error, "status_code", 422)
         raise exception_response(status_code, detail=text_type(error))
 
     def use_args(

--- a/webargs/pyramidparser.py
+++ b/webargs/pyramidparser.py
@@ -78,7 +78,9 @@ class PyramidParser(core.Parser):
         responds with a 400 error.
         """
         status_code = error_status_code or getattr(error, "status_code", 422)
-        raise exception_response(status_code, detail=text_type(error))
+        raise exception_response(
+            status_code, detail=text_type(error), headers=error_headers
+        )
 
     def use_args(
         self,
@@ -87,6 +89,8 @@ class PyramidParser(core.Parser):
         locations=core.Parser.DEFAULT_LOCATIONS,
         as_kwargs=False,
         validate=None,
+        error_status_code=None,
+        error_headers=None,
     ):
         """Decorator that injects parsed arguments into a view callable.
         Supports the *Class-based View* pattern where `request` is saved as an instance
@@ -123,6 +127,8 @@ class PyramidParser(core.Parser):
                     locations=locations,
                     validate=validate,
                     force_all=as_kwargs,
+                    error_status_code=error_status_code,
+                    error_headers=error_headers,
                 )
                 if as_kwargs:
                     kwargs.update(parsed_args)

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -26,6 +26,7 @@ class HTTPError(tornado.web.HTTPError):
 
     def __init__(self, *args, **kwargs):
         self.messages = kwargs.pop("messages", {})
+        self.headers = kwargs.pop("headers", None)
         super(HTTPError, self).__init__(*args, **kwargs)
 
 
@@ -129,6 +130,7 @@ class TornadoParser(core.Parser):
             log_message=str(error.messages),
             reason=reason,
             messages=error.messages,
+            headers=error_headers,
         )
 
     def get_request_from_view_args(self, view, args, kwargs):

--- a/webargs/tornadoparser.py
+++ b/webargs/tornadoparser.py
@@ -113,11 +113,13 @@ class TornadoParser(core.Parser):
         """Pull a file from the request."""
         return get_value(req.files, name, field)
 
-    def handle_error(self, error, req, schema):
+    def handle_error(self, error, req, schema, error_status_code, error_headers):
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`
         with a 400 error.
         """
-        status_code = getattr(error, "status_code", core.DEFAULT_VALIDATION_STATUS)
+        status_code = error_status_code or getattr(
+            error, "status_code", core.DEFAULT_VALIDATION_STATUS
+        )
         if status_code == 422:
             reason = "Unprocessable Entity"
         else:


### PR DESCRIPTION
* `status_code` and `headers` kwargs are deprecated (close #336)
* Add `error_status_code` and `error_headers`:
  See https://github.com/sloria/webargs/issues/327#issuecomment-449669326

```python
def validate_foo(val):  # Before
    ...
    raise ValidationError("Error!", status_code=400)

@use_args({"foo": fields.Str(validate=validate_foo)})
def my_view(args):
    ...

def validate_foo(val):  # After
    ...
    raise ValidationError("Error!")

@use_args(
    {"foo": fields.Str(validate=validate_foo)},
    error_status_code=400
)
def my_view(args):
    ...
```

* error_handler functions and handle_error methods now take
  error_status_code and error_headers arguments. Backwards
  compatibility was maintained by checking the the number of
  arguments in the signatures.

```python
@parser.error_handler
def handle_error(error, req):  # Before
    raise CustomError(error.messages)

@parser.error_handler
def handle_error(error, req, status_code, headers):  # After
    raise CustomError(error.messages)

@parser.error_handler
def handle_error(error, **kwargs):  # Also works
    raise CustomError(error.messages)
```