### PR TITLE
Rename and deprecate argmap2schema in favor of dict2schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+4.4.0 (unreleased)
+******************
+
+* *Deprecation*: ``argmap2schema`` is deprecated in favor of
+  ``dict2schema``.
+
 4.3.1 (2018-12-31)
 ******************
 

--- a/webargs/__init__.py
+++ b/webargs/__init__.py
@@ -4,7 +4,7 @@ from marshmallow.utils import missing
 # Make marshmallow's validation functions importable from webargs
 from marshmallow import validate
 
-from webargs.core import argmap2schema, WebargsError, ValidationError
+from webargs.core import argmap2schema, dict2schema, WebargsError, ValidationError
 from webargs import fields
 
 __version__ = "4.3.1"
@@ -13,6 +13,7 @@ __license__ = "MIT"
 
 
 __all__ = (
+    "dict2schema",
     "argmap2schema",
     "WebargsError",
     "ValidationError",

--- a/webargs/core.py
+++ b/webargs/core.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "WebargsError",
     "ValidationError",
-    "argmap2schema",
+    "dict2schema",
     "is_multiple",
     "Parser",
     "get_value",
@@ -137,11 +137,11 @@ def fill_in_missing_args(ret, argmap):
     return ret
 
 
-def argmap2schema(argmap):
-    """Generate a `marshmallow.Schema` class given a dictionary of argument
-    names to `Fields <marshmallow.fields.Field>`.
+def dict2schema(dct):
+    """Generate a `marshmallow.Schema` class given a dictionary of
+    `Fields <marshmallow.fields.Field>`.
     """
-    attrs = argmap.copy()
+    attrs = dct.copy()
     if MARSHMALLOW_VERSION_INFO[0] < 3:
 
         class Meta(object):
@@ -149,6 +149,14 @@ def argmap2schema(argmap):
 
         attrs["Meta"] = Meta
     return type(str(""), (ma.Schema,), attrs)
+
+
+def argmap2schema(argmap):
+    warnings.warn(
+        "argmap2schema is deprecated. Use dict2schema instead.",
+        RemovedInWebargs5Warning,
+    )
+    return dict2schema(argmap)
 
 
 def is_multiple(field):
@@ -423,7 +431,7 @@ class Parser(object):
         elif callable(argmap):
             schema = argmap(req)
         else:
-            schema = argmap2schema(argmap)()
+            schema = dict2schema(argmap)()
         if MARSHMALLOW_VERSION_INFO[0] < 3 and not schema.strict:
             warnings.warn(
                 "It is highly recommended that you set strict=True on your schema "
@@ -555,7 +563,7 @@ class Parser(object):
         # Optimization: If argmap is passed as a dictionary, we only need
         # to generate a Schema once
         if isinstance(argmap, collections.Mapping):
-            argmap = argmap2schema(argmap)()
+            argmap = dict2schema(argmap)()
 
         def decorator(func):
             req_ = request_obj


### PR DESCRIPTION
There's nothing webargs-specific about the function,
so the more general "dict2schema" is more appropriate