### PR TITLE
Fix Flask<1.0 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Features:
 
 Bug fixes:
 
+* Fix compatibility with Flask<1.0 (:issue:`355`).
+  Thanks :user:`hoatle` for reporting.
 * Address warning on Python 3.7 about importing from ``collections.abc``.
 
 5.0.0 (2019-01-03)

--- a/webargs/flaskparser.py
+++ b/webargs/flaskparser.py
@@ -60,7 +60,7 @@ class FlaskParser(core.Parser):
             # We decode the json manually here instead of
             # using req.get_json() so that we can handle
             # JSONDecodeErrors consistently
-            data = req._get_data_for_json(cache=True)
+            data = req.get_data(cache=True)
             try:
                 self._cache["json"] = json_data = core.parse_json(data)
             except json.JSONDecodeError as e:


### PR DESCRIPTION
Use Request.get_data rather than the private _get_data_for_json,
which doesn't exist on pre-1.0 Flask versions.

Confirmed tests are passing for both Flask 0.12.4 and 1.0.2

close #355