### PR TITLE
Prepare for marshmallow 3.0.0rc6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ jobs:
   - { python: '3.6', env: TOXENV=lint }
 
   - { python: '2.7', env: TOXENV=py27-marshmallow2 }
-  - { python: '2.7', env: TOXENV=py27-marshmallow3 }
 
   - { python: '3.5', env: TOXENV=py35-marshmallow2 }
   - { python: '3.5', env: TOXENV=py35-marshmallow3 }

--- a/src/webargs/compat.py
+++ b/src/webargs/compat.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+import sys
+
+PY2 = int(sys.version_info[0]) == 2
+
+if PY2:
+    from collections import Mapping
+
+    basestring = basestring
+    text_type = unicode
+    iteritems = lambda d: d.iteritems()
+else:
+    from collections.abc import Mapping
+
+    basestring = (str, bytes)
+    text_type = str
+    iteritems = lambda d: d.items()

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -9,19 +9,15 @@ from copy import copy
 from distutils.version import LooseVersion
 
 try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
-
-try:
     import simplejson as json
 except ImportError:
     import json  # type: ignore
 
 import marshmallow as ma
 from marshmallow import ValidationError
-from marshmallow.compat import iteritems
 from marshmallow.utils import missing, is_collection
+
+from webargs.compat import Mapping, iteritems
 
 logger = logging.getLogger(__name__)
 

--- a/src/webargs/pyramidparser.py
+++ b/src/webargs/pyramidparser.py
@@ -31,9 +31,9 @@ import functools
 from webob.multidict import MultiDict
 from pyramid.httpexceptions import exception_response
 
-from marshmallow.compat import text_type
 from webargs import core
 from webargs.core import json
+from webargs.compat import text_type
 
 
 class PyramidParser(core.Parser):

--- a/src/webargs/tornadoparser.py
+++ b/src/webargs/tornadoparser.py
@@ -17,8 +17,8 @@ Example: ::
 import tornado.web
 from tornado.escape import _unicode
 
-from marshmallow.compat import basestring
 from webargs import core
+from webargs.compat import basestring
 from webargs.core import json
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist=
     lint
-    py{27,35,36,37}-marshmallow{2,3}
+    py{27,35,36,37}-marshmallow2
+    py{35,36,37}-marshmallow3
     docs
 
 [testenv]


### PR DESCRIPTION
* Don't test against marshmallow 3 in Python 3 environments
* Remove usages of marshmallow.compat, which is removed
  in marshmallow 3