### PR TITLE
Pass all args to schemas, but default to unknown=EXCLUDE (work in progress)

### DIFF
--- a/src/webargs/djangoparser.py
+++ b/src/webargs/djangoparser.py
@@ -33,16 +33,7 @@ class DjangoParser(core.Parser):
         the parser and returning the appropriate `HTTPResponse`.
     """
 
-    def parse_querystring(self, req, name, field):
-        """Pull the querystring value from the request."""
-        return core.get_value(req.GET, name, field)
-
-    def parse_form(self, req, name, field):
-        """Pull the form value from the request."""
-        return core.get_value(req.POST, name, field)
-
-    def parse_json(self, req, name, field):
-        """Pull a json value from the request body."""
+    def _load_json_data(self, req):
         json_data = self._cache.get("json")
         if json_data is None:
             try:
@@ -54,6 +45,49 @@ class DjangoParser(core.Parser):
                     return core.missing
                 else:
                     return self.handle_invalid_json_error(e, req)
+        return json_data
+
+    def get_args_by_location(self, req, locations):
+        result = {}
+        if "json" in locations:
+            try:
+                data = self._load_json_data(req)
+            except json.JSONDecodeError:
+                data = core.missing
+            if isinstance(data, dict):
+                data = data.keys()
+            # this is slightly unintuitive, but if we parse JSON which is
+            # not a dict, we don't know any arg names
+            else:
+                data = core.missing
+            result["json"] = data
+        if "querystring" in locations:
+            result["querystring"] = req.GET.keys()
+        if "query" in locations:
+            result["query"] = req.GET.keys()
+        if "form" in locations:
+            result["form"] = req.POST.keys()
+        if "headers" in locations:
+            raise NotImplementedError(
+                "Header parsing not supported by {0}".format(self.__class__.__name__)
+            )
+        if "cookies" in locations:
+            result["cookies"] = req.COOKIES.keys()
+        if "files" in locations:
+            result["files"] = req.FILES.keys()
+        return result
+
+    def parse_querystring(self, req, name, field):
+        """Pull the querystring value from the request."""
+        return core.get_value(req.GET, name, field)
+
+    def parse_form(self, req, name, field):
+        """Pull the form value from the request."""
+        return core.get_value(req.POST, name, field)
+
+    def parse_json(self, req, name, field):
+        """Pull a json value from the request body."""
+        json_data = self._load_json_data(req)
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_cookies(self, req, name, field):

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -76,7 +76,12 @@ class FlaskParser(core.Parser):
         if "json" in locations:
             data = self._load_json_data(req)
             if data is not core.missing:
-                data = data.keys()
+                if isinstance(data, dict):
+                    data = data.keys()
+                # this is slightly unintuitive, but if we parse JSON which is
+                # not a dict, we don't know any arg names
+                else:
+                    data = core.missing
             result["json"] = data
         if "querystring" in locations:
             result["querystring"] = req.args.keys()

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -53,12 +53,7 @@ class FlaskParser(core.Parser):
         **core.Parser.__location_map__
     )
 
-    def parse_view_args(self, req, name, field):
-        """Pull a value from the request's ``view_args``."""
-        return core.get_value(req.view_args, name, field)
-
-    def parse_json(self, req, name, field):
-        """Pull a json value from the request."""
+    def _load_json_data(self, req):
         json_data = self._cache.get("json")
         if json_data is None:
             # We decode the json manually here instead of
@@ -72,6 +67,39 @@ class FlaskParser(core.Parser):
                     return core.missing
                 else:
                     return self.handle_invalid_json_error(e, req)
+        return json_data
+
+    def get_args_by_location(self, req, locations):
+        result = {}
+        if "view_args" in locations:
+            result["view_args"] = req.view_args.keys()
+        if "json" in locations:
+            data = self._load_json_data(req)
+            if data is not core.missing:
+                data = data.keys()
+            result["json"] = data
+        if "querystring" in locations:
+            result["querystring"] = req.args.keys()
+        if "query" in locations:
+            result["query"] = req.args.keys()
+        if "form" in locations:
+            result["form"] = req.form.keys()
+        if "headers" in locations:
+            result["headers"] = req.headers.keys()
+        if "cookies" in locations:
+            result["cookies"] = req.cookies.keys()
+        if "files" in locations:
+            result["files"] = req.files.keys()
+
+        return result
+
+    def parse_view_args(self, req, name, field):
+        """Pull a value from the request's ``view_args``."""
+        return core.get_value(req.view_args, name, field)
+
+    def parse_json(self, req, name, field):
+        """Pull a json value from the request."""
+        json_data = self._load_json_data(req)
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -73,15 +73,19 @@ class FlaskParser(core.Parser):
         result = {}
         if "view_args" in locations:
             result["view_args"] = req.view_args.keys()
+        if "path" in locations:
+            result["path"] = req.view_args.keys()
         if "json" in locations:
-            data = self._load_json_data(req)
-            if data is not core.missing:
-                if isinstance(data, dict):
-                    data = data.keys()
-                # this is slightly unintuitive, but if we parse JSON which is
-                # not a dict, we don't know any arg names
-                else:
-                    data = core.missing
+            try:
+                data = self._load_json_data(req)
+            except HTTPException:
+                data = core.missing
+            if isinstance(data, dict):
+                data = data.keys()
+            # this is slightly unintuitive, but if we parse JSON which is
+            # not a dict, we don't know any arg names
+            else:
+                data = core.missing
             result["json"] = data
         if "querystring" in locations:
             result["querystring"] = req.args.keys()

--- a/src/webargs/tornadoparser.py
+++ b/src/webargs/tornadoparser.py
@@ -82,8 +82,7 @@ def get_value(d, name, field):
 class TornadoParser(core.Parser):
     """Tornado request argument parser."""
 
-    def parse_json(self, req, name, field):
-        """Pull a json value from the request."""
+    def _load_json_data(self, req):
         json_data = self._cache.get("json")
         if json_data is None:
             try:
@@ -92,6 +91,39 @@ class TornadoParser(core.Parser):
                 return self.handle_invalid_json_error(e, req)
             if json_data is None:
                 return core.missing
+        return json_data
+
+    def get_args_by_location(self, req, locations):
+        result = {}
+        if "json" in locations:
+            try:
+                data = self._load_json_data(req)
+            except HTTPError:
+                data = core.missing
+            if isinstance(data, dict):
+                data = data.keys()
+            # this is slightly unintuitive, but if we parse JSON which is
+            # not a dict, we don't know any arg names
+            else:
+                data = core.missing
+            result["json"] = data
+        if "querystring" in locations:
+            result["querystring"] = req.query_arguments.keys()
+        if "query" in locations:
+            result["query"] = req.query_arguments.keys()
+        if "form" in locations:
+            result["form"] = req.body_arguments.keys()
+        if "headers" in locations:
+            result["headers"] = req.headers.keys()
+        if "cookies" in locations:
+            result["cookies"] = req.cookies.keys()
+        if "files" in locations:
+            result["files"] = req.files.keys()
+        return result
+
+    def parse_json(self, req, name, field):
+        """Pull a json value from the request."""
+        json_data = self._load_json_data(req)
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):

--- a/src/webargs/webapp2parser.py
+++ b/src/webargs/webapp2parser.py
@@ -37,8 +37,12 @@ from webargs.core import json
 class Webapp2Parser(core.Parser):
     """webapp2 request argument parser."""
 
-    def parse_json(self, req, name, field):
-        """Pull a json value from the request."""
+    def _load_files_mdict(self, req):
+        return webob.multidict.MultiDict(
+            (k, v) for k, v in req.POST.items() if hasattr(v, "file")
+        )
+
+    def _load_json_data(self, req):
         json_data = self._cache.get("json")
         if json_data is None:
             try:
@@ -48,6 +52,39 @@ class Webapp2Parser(core.Parser):
                     return core.missing
                 else:
                     raise
+        return json_data
+
+    def get_args_by_location(self, req, locations):
+        result = {}
+        if "json" in locations:
+            try:
+                data = self._load_json_data(req)
+            except json.JSONDecodeError:
+                data = core.missing
+            if isinstance(data, dict):
+                data = data.keys()
+            # this is slightly unintuitive, but if we parse JSON which is
+            # not a dict, we don't know any arg names
+            else:
+                data = core.missing
+            result["json"] = data
+        if "querystring" in locations:
+            result["querystring"] = req.GET.keys()
+        if "query" in locations:
+            result["query"] = req.GET.keys()
+        if "form" in locations:
+            result["form"] = req.POST.keys()
+        if "headers" in locations:
+            result["headers"] = req.headers.keys()
+        if "cookies" in locations:
+            result["cookies"] = req.cookies.keys()
+        if "files" in locations:
+            result["files"] = self._load_files_mdict(req).keys()
+        return result
+
+    def parse_json(self, req, name, field):
+        """Pull a json value from the request."""
+        json_data = self._load_json_data(req)
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_querystring(self, req, name, field):
@@ -68,8 +105,7 @@ class Webapp2Parser(core.Parser):
 
     def parse_files(self, req, name, field):
         """Pull a file from the request."""
-        files = ((k, v) for k, v in req.POST.items() if hasattr(v, "file"))
-        return core.get_value(webob.multidict.MultiDict(files), name, field)
+        return core.get_value(self._load_files_mdict(req), name, field)
 
     def get_default_request(self):
         return webapp2.get_request()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -959,18 +959,36 @@ def test_parse_basic(web_request, parser):
     MARSHMALLOW_VERSION_INFO[0] < 3,
     reason="Support for unknown=... was added in marshmallow 3",
 )
-def test_parse_with_unknown_raises_schema(web_request, parser, monkeypatch):
+def test_parse_with_unknown_raise_set_by_schema(web_request, parser, monkeypatch):
     from marshmallow import RAISE
 
-    class RaisingSchema(Schema):
+    class MySchema(Schema):
         foo = fields.Int()
 
-    raising_schema = RaisingSchema(unknown=RAISE)
+    raising_schema = MySchema(unknown=RAISE)
 
     web_request.json = {"foo": "42", "bar": "baz"}
-    monkeypatch.setattr(parser, "pass_all_args", True)
+    monkeypatch.setattr(parser, "unknown", None)
     with pytest.raises(ValidationError):
         parser.parse(raising_schema, web_request)
+
+
+@pytest.mark.skipif(
+    MARSHMALLOW_VERSION_INFO[0] < 3,
+    reason="Support for unknown=... was added in marshmallow 3",
+)
+def test_parse_with_unknown_raise_set_by_parser(web_request, parser, monkeypatch):
+    from marshmallow import RAISE
+
+    class MySchema(Schema):
+        foo = fields.Int()
+
+    schema = MySchema()
+
+    web_request.json = {"foo": "42", "bar": "baz"}
+    monkeypatch.setattr(parser, "unknown", RAISE)
+    with pytest.raises(ValidationError):
+        parser.parse(schema, web_request)
 
 
 def test_parse_raises_validation_error_if_data_invalid(web_request, parser):


### PR DESCRIPTION
This is a work in progress / demonstration of a solution for #267 .
It's based on the suggestion in that thread (big thanks to @toonalbers for that!).

I did two versions of this and have kept it in separate commits so that both can be reviewed if desirable. I prefer the latter form and will squash the work if it's going to be accepted in a form even remotely like this.

In the first version, if Parser.pass_all_args is set (it defaults to false for backwards compatibility), then argument parsing becomes a two step process.
First, args are parsed based on the schema fields, as today. Then, second, they are all treated as `marshmallow.fields.Raw`, parsed by webargs, and the result of that parsing is passed to the schema for validation.
If Parser.pass_all_args is set on marshmallow versions < 3, it is a ValueError.

As a refinement on this, I successfully swapped out Parser.pass_all_args for Parser.unknown, which sets the value to pass for `Schema.load(unknown=...)`. On marshmallow v3, it defaults to `EXCLUDE`, which makes this backwards-compatible. Callers may pass `None` to send no value and obey the schema default. All arguments are *always* passed to the schema, and we're just using the very `unknown=...` behavior we're trying to expose to maintain backwards compatibility.

(Note: this is arguable backwards *incompatible* because certain usages with strict schema validators were passing and will start to fail.)

In both versions, in order to collect arguments to pass to the schema, this adds a new function required on all parsers, `get_args_by_location`, which collects all argument names, typically dict keys, categorized by location name.
This is only implemented here in the flask parser, as a proof of concept.

There's a lot more work that I would need to do for this to be ready to merge. Namely:
- many more tests
- support in all built-in parsers for `get_args_by_location`

However, I don't want to put in the labor to do the kind of testing I think this change needs without gettings eyes on this work from a webargs maintainer and confirmation that this whole approach is okay. If it is, I'll happily put together the necessary work to make all of the parsers handle this and do a lot more testing.