### PR TITLE
Ensure a compatible version of marshmallow is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 import re
 from setuptools import setup, find_packages
 
-INSTALL_REQUIRES = ["marshmallow>=2.15.2"]
+INSTALL_REQUIRES = ["marshmallow>=2.15.2,<3.0.0"]
 if sys.version_info[0] < 3:
     INSTALL_REQUIRES.append("simplejson>=2.1.0")
 


### PR DESCRIPTION
`marshmallow` 3.0.0 has made a breaking change since `marshmallow.compat` no longer exists. That module is used in several locations.