### PR TITLE
Add documentation about marshmallow-dataclass

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -74,10 +74,13 @@ When you need more flexibility in defining input schemas, you can pass a marshma
     If you're using marshmallow 2, you should always set ``strict=True`` (either as a ``class Meta`` option or in the Schema's constructor) when passing a schema to webargs. This will ensure that the parser's error handler is invoked when expected.
 
 
-When not to use `use_kwargs`
-----------------------------
+When to avoid `use_kwargs`
+--------------------------
 
-Any Schema passed to use_kwargs MUST deserialize to a dictionary of data. If you are relying on schemas that provide `post_load <marshmallow.decorators.post_load>` methods that end up transforming the result, then you should instead rely on use_args.
+Any  `Schema <marshmallow.Schema>` passed to `use_kwargs <webargs.core.Parser.use_kwargs>` MUST deserialize to a dictionary of data.
+If your schema has a `post_load <marshmallow.decorators.post_load>` method 
+that returns a non-dictionary,
+you should use `use_args <webargs.core.Parser.use_args>` instead.
 
 .. code-block:: python
 
@@ -85,24 +88,24 @@ Any Schema passed to use_kwargs MUST deserialize to a dictionary of data. If you
     from webargs.flaskparser import use_args
 
     class Rectangle:
-    def __init__(self, length, width):
-        self.length = length
-        self.width = width
+        def __init__(self, length, width):
+            self.length = length
+            self.width = width
 
     class RectangleSchema(Schema):
-        __model__ = Rectangle
         length = fields.Float()
         width = fields.Float()
 
         @post_load
         def make_object(self, data, **kwargs):
-            return self.__model__(**data)
+            return Rectangle(**data)
 
     @use_args(RectangleSchema)
     def post(self, rect: Rectangle):
         return f"Area: {rect.length * rect.width}"
 
-For example, `marshmallow-dataclass <https://github.com/lovasoa/marshmallow_dataclass>`_ and `marshmallow-sqlalchemy <https://github.com/marshmallow-code/marshmallow-sqlalchemy>`_ can help generate schemas to be used with webargs. However, these schemas will deserialize content into a objects and models that can't be treated as dictionaries.
+Packages such as  `marshmallow-sqlalchemy <https://github.com/marshmallow-code/marshmallow-sqlalchemy>`_ and `marshmallow-dataclass <https://github.com/lovasoa/marshmallow_dataclass>`_ generate schemas that deserialize to non-dictionary objects.
+Therefore, `use_args <webargs.core.Parser.use_args>` should be used with those schemas.
 
 
 Schema Factories

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -77,6 +77,29 @@ When you need more flexibility in defining input schemas, you can pass a marshma
     Any `Schema <marshmallow.Schema>` passed to `use_kwargs <webargs.core.Parser.use_kwargs>` MUST deserialize to a dictionary of data. Keep this in mind when writing `post_load <marshmallow.decorators.post_load>` methods.
 
 
+marshmallow-dataclass Integration
+-----------------------
+
+Marshmallow dataclass can be used to provide schemas built from python3 dataclasses. However, these schemas will deserialize content into a dataclass and NOT a dictionary, meaning that `use_args <webargs.core.Parser.use_args>` must be used with a Schema or "Schema factory" instead of use_kwargs.
+
+
+.. code-block:: python
+
+    from marshmallow_dataclass import dataclass
+    from webargs.flaskparser import use_args
+
+
+    @dataclass
+    class Greeting:
+        name: str
+        prefix: str = "Hello"
+
+
+    @use_args(Greeting.Schema)
+    def profile_posts(greeting: Greeting):
+        return f"{greeting.prefix} {greeting.name}"
+
+
 Schema Factories
 ----------------
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -87,10 +87,12 @@ you should use `use_args <webargs.core.Parser.use_args>` instead.
     from marshmallow import Schema, fields, post_load
     from webargs.flaskparser import use_args
 
+
     class Rectangle:
         def __init__(self, length, width):
             self.length = length
             self.width = width
+
 
     class RectangleSchema(Schema):
         length = fields.Float()
@@ -99,6 +101,7 @@ you should use `use_args <webargs.core.Parser.use_args>` instead.
         @post_load
         def make_object(self, data, **kwargs):
             return Rectangle(**data)
+
 
     @use_args(RectangleSchema)
     def post(self, rect: Rectangle):


### PR DESCRIPTION
Webargs already works out of the box with [marshmallow-dataclass](https://github.com/lovasoa/marshmallow_dataclass), however there are some [tripping points](https://github.com/lovasoa/marshmallow_dataclass/issues/42) one can run into if you miss the warnings associated with `use_kwargs`, which expects all schemas to deserialize into a dictionary. An assumption not maintained by marshmallow-dataclass _by design_. A reminder to rely on `use_args` instead could help alleviate the confusion I experienced.

I've included a simple example of how I would use marshmallow-dataclass demonstrating how to deserialize requests into dataclasses with type hints.