### PR TITLE
Add tests / test files to sdist

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,3 +41,5 @@ Contributors (chronological)
 * Jonathan Angelo <https://github.com/jangelo>
 * @zhenhua32 <https://github.com/zhenhua32>
 * Martin Roy <https://github.com/lindycoder>
+* Kubilay Kocak <https://github.com/koobs>
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
+graft tests
 include LICENSE
 include *.rst
+include tox.ini


### PR DESCRIPTION
Add tests and related test files to the MANIFEST.in in order to include them in the PyPI sdist

This allows downstream users, including OS packagers to test the package using the source distribution

Note: setup.py:packages already includes an exclusion for packages matching test* to preclude it from being installed