### PR TITLE
BREAKING: upgrade to falcon 2.0 compatibility

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,3 +43,5 @@ Contributors (chronological)
 * Martin Roy <https://github.com/lindycoder>
 * Kubilay Kocak <https://github.com/koobs>
 * Stephen Rosen <https://github.com/sirosen>
+* @dodumosu <https://github.com/dodumosu>
+* Nate Dellinger <https://github.com/Nateyo>

--- a/docs/framework_support.rst
+++ b/docs/framework_support.rst
@@ -310,7 +310,7 @@ You can easily implement hooks by using `parser.parse <webargs.falconparser.Falc
 
 
     def add_args(argmap, **kwargs):
-        def hook(req, resp, params):
+        def hook(req, resp, resource, params):
             parsed_args = parser.parse(argmap, req=req, **kwargs)
             req.context["args"] = parsed_args
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ FRAMEWORKS = [
     "tornado>=4.5.2",
     "pyramid>=1.9.1",
     "webapp2>=3.0.0b1",
-    "falcon>=1.4.0,<2.0",
+    "falcon>=2.0.0",
     "aiohttp>=3.0.0",
 ]
 EXTRAS_REQUIRE = {

--- a/src/webargs/falconparser.py
+++ b/src/webargs/falconparser.py
@@ -35,7 +35,7 @@ def parse_form_body(req):
         req.content_type is not None
         and "application/x-www-form-urlencoded" in req.content_type
     ):
-        body = req.stream.read()
+        body = req.stream.read(req.content_length or 0)
         try:
             body = body.decode("ascii")
         except UnicodeDecodeError:
@@ -48,9 +48,7 @@ def parse_form_body(req):
             )
 
         if body:
-            return parse_query_string(
-                body, keep_blank_qs_values=req.options.keep_blank_qs_values
-            )
+            return parse_query_string(body, keep_blank=req.options.keep_blank_qs_values)
 
     return core.missing
 

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -148,7 +148,7 @@ class EchoNestedMany:
 
 
 def use_args_hook(args, context_key="args", **kwargs):
-    def hook(req, resp, params):
+    def hook(req, resp, resource, params):
         parsed_args = parser.parse(args, req=req, **kwargs)
         req.context[context_key] = parsed_args
 


### PR DESCRIPTION
Following the thread on the open PR, this should resolve any issues with falcon 2.0 compatibility, and as discussed moving forward for webargs-6, the setup.py explicitly lists `falcon>=2.0.0`

I've updated docs and all tests work, although I didn't run the full tox tests.

Relevant open PRs:
#449 

Relevant open issues:
#448 