### PR TITLE
Remove the Parser cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+6.0.0b6 (Unreleased)
+********************
+
+Refactoring:
+
+* Remove the cache attached to webargs parsers. Due to changes between webargs
+  v5 and v6, the cache is no longer considered useful.
+
 6.0.0b5 (2020-01-30)
 ********************
 

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -35,7 +35,6 @@ class AsyncParser(core.Parser):
 
         Receives the same arguments as `webargs.core.Parser.parse`.
         """
-        self.clear_cache()  # in case someone used `location_load_*()`
         req = req if req is not None else self.get_default_request()
         if req is None:
             raise ValueError("Must pass req object")

--- a/src/webargs/falconparser.py
+++ b/src/webargs/falconparser.py
@@ -91,9 +91,7 @@ class FalconParser(core.Parser):
 
             The request stream will be read and left at EOF.
         """
-        form = self._cache.get("form")
-        if form is None:
-            self._cache["form"] = form = parse_form_body(req)
+        form = parse_form_body(req)
         if form is core.missing:
             return form
         return MultiDictProxy(form, schema)

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -1,5 +1,3 @@
-import threading
-
 from werkzeug.exceptions import HTTPException
 import pytest
 
@@ -126,37 +124,3 @@ def test_abort_has_serializable_data():
     error = json.loads(serialized_error)
     assert isinstance(error, dict)
     assert error["message"] == "custom error message"
-
-
-def test_json_cache_race_condition():
-    app = Flask("testapp")
-    lock = threading.Lock()
-    lock.acquire()
-
-    class MyField(fields.Field):
-        def _deserialize(self, value, attr, data, **kwargs):
-            with lock:
-                return value
-
-    argmap = {"value": MyField()}
-    results = {}
-
-    def thread_fn(value):
-        with app.test_request_context(
-            "/foo",
-            method="post",
-            data=json.dumps({"value": value}),
-            content_type="application/json",
-        ):
-            results[value] = parser.parse(argmap)["value"]
-
-    t1 = threading.Thread(target=thread_fn, args=(42,))
-    t2 = threading.Thread(target=thread_fn, args=(23,))
-    t1.start()
-    t2.start()
-    lock.release()
-    t1.join()
-    t2.join()
-    # ensure we didn't get contaminated by a parallel request
-    assert results[42] == 42
-    assert results[23] == 23

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -51,9 +51,6 @@ def test_tornado_multidictproxy():
 
 
 class TestQueryArgs:
-    def setup_method(self, method):
-        parser.clear_cache()
-
     def test_it_should_get_single_values(self):
         query = [("name", "Aeschylus")]
         request = make_get_request(query)
@@ -75,9 +72,6 @@ class TestQueryArgs:
 
 
 class TestFormArgs:
-    def setup_method(self, method):
-        parser.clear_cache()
-
     def test_it_should_get_single_values(self):
         query = [("name", "Aristophanes")]
         request = make_form_request(query)
@@ -99,9 +93,6 @@ class TestFormArgs:
 
 
 class TestJSONArgs:
-    def setup_method(self, method):
-        parser.clear_cache()
-
     def test_it_should_get_single_values(self):
         query = {"name": "Euripides"}
         request = make_json_request(query)
@@ -162,14 +153,10 @@ class TestJSONArgs:
     def test_it_should_handle_value_error_on_parse_json(self):
         request = make_request("this is json not")
         result = parser.load_json(request, author_schema)
-        assert parser._cache.get("json") == missing
         assert result is missing
 
 
 class TestHeadersArgs:
-    def setup_method(self, method):
-        parser.clear_cache()
-
     def test_it_should_get_single_values(self):
         query = {"name": "Euphorion"}
         request = make_request(headers=query)
@@ -190,9 +177,6 @@ class TestHeadersArgs:
 
 
 class TestFilesArgs:
-    def setup_method(self, method):
-        parser.clear_cache()
-
     def test_it_should_get_single_values(self):
         query = [("name", "Sappho")]
         request = make_files_request(query)
@@ -221,9 +205,6 @@ class TestErrorHandler:
 
 
 class TestParse:
-    def setup_method(self, method):
-        parser.clear_cache()
-
     def test_it_should_parse_query_arguments(self):
         attrs = {"string": fields.Field(), "integer": fields.List(fields.Int())}
 
@@ -322,9 +303,6 @@ class TestParse:
 
 
 class TestUseArgs:
-    def setup_method(self, method):
-        parser.clear_cache()
-
     def test_it_should_pass_parsed_as_first_argument(self):
         class Handler:
             request = make_json_request({"key": "value"})


### PR DESCRIPTION
Because the cache is no longer used field-by-field to fetch data, there's significantly less value in keeping it. Combined with the fact that each parser instantiation was already clearing the cache to avoid a security bug ( #371 ), the cache is no longer actually used at all in most (any?) contexts.

Remove the cache and all of the machinery associated with it (Parser._clear_cache, Parser._clone, and relevant checks).

Resolves #374

---

If there's some case I'm not aware of in which the cache is really useful, that's fine. But based on my reading, I don't think it really does anything anymore, so I'm proposing its removal.