### PR TITLE
Inject the location into ValidationErrors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+6.0.0b7 (Unreleased)
+********************
+
+Features:
+
+* *Backwards-incompatible*: webargs will rewrite the error messages in
+  ValidationErrors to be namespaced under the location which raised the error.
+  The `messages` field on errors will therefore be one layer deeper with a
+  single top-level key.
+
 6.0.0b6 (2020-01-31)
 ********************
 

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -36,6 +36,7 @@ class AsyncParser(core.Parser):
         Receives the same arguments as `webargs.core.Parser.parse`.
         """
         req = req if req is not None else self.get_default_request()
+        location = location or self.location
         if req is None:
             raise ValueError("Must pass req object")
         data = None
@@ -43,14 +44,14 @@ class AsyncParser(core.Parser):
         schema = self._get_schema(argmap, req)
         try:
             location_data = await self._load_location_data(
-                schema=schema, req=req, location=location or self.location
+                schema=schema, req=req, location=location
             )
             result = schema.load(location_data)
             data = result.data if core.MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:
             await self._on_validation_error(
-                error, req, schema, error_status_code, error_headers
+                error, req, schema, location, error_status_code, error_headers
             )
         return data
 
@@ -78,9 +79,16 @@ class AsyncParser(core.Parser):
         error: ValidationError,
         req: Request,
         schema: Schema,
+        location: str,
         error_status_code: typing.Union[int, None],
         error_headers: typing.Union[typing.Mapping[str, str], None] = None,
     ) -> None:
+        # rewrite messages to be namespaced under the location which created
+        # them
+        # e.g. {"json":{"foo":["Not a valid integer."]}}
+        #      instead of
+        #      {"foo":["Not a valid integer."]}
+        error.messages = {location: error.messages}
         error_handler = self.error_callback or self.handle_error
         await error_handler(error, req, schema, error_status_code, error_headers)
 

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -212,4 +212,16 @@ def echo_use_kwargs_missing(username, **kwargs):
 def handle_error(err):
     if err.code == 422:
         assert isinstance(err.data["schema"], ma.Schema)
-    return J(err.data["messages"]), err.code
+    try:
+        return J(err.data["messages"]), err.code
+    # on marshmallow2, validation errors for nested schemas can fail to encode:
+    # https://github.com/marshmallow-code/marshmallow/issues/493
+    # to workaround this, convert integer keys to strings
+    except TypeError:
+
+        def tweak_data(value):
+            if not isinstance(value, dict):
+                return value
+            return {str(k): v for k, v in value.items()}
+
+        return J({k: tweak_data(v) for k, v in err.data["messages"].items()}), err.code

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -28,7 +28,7 @@ class TestFlaskParser(CommonTestCase):
     def test_parsing_invalid_view_arg(self, testapp):
         res = testapp.get("/echo_view_arg/foo", expect_errors=True)
         assert res.status_code == 422
-        assert res.json == {"view_arg": ["Not a valid integer."]}
+        assert res.json == {"view_args": {"view_arg": ["Not a valid integer."]}}
 
     def test_use_args_with_view_args_parsing(self, testapp):
         res = testapp.get("/echo_view_arg_use_args/42")
@@ -87,7 +87,7 @@ def test_abort_called_on_validation_error(mock_abort):
     abort_args, abort_kwargs = mock_abort.call_args
     assert abort_args[0] == 422
     expected_msg = "Invalid value."
-    assert abort_kwargs["messages"]["value"] == [expected_msg]
+    assert abort_kwargs["messages"]["json"]["value"] == [expected_msg]
     assert type(abort_kwargs["exc"]) == ValidationError
 
 


### PR DESCRIPTION
In order to ensure that errors are always unambiguous, add the `location` to the message data for ValidationErrors.
This is done by adding a new level of nesting to the error messages, putting errors under the location as a new top-level key.

Resolves #460

---

I'm putting this in a PR to evaluate it, but I'm not 100% comitted to this solution. I'm going to ask a couple of questions on #460 to try to better understand what the options are.