### PR TITLE
stdlib `wsgiref` requires argument for `read()`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -46,3 +46,4 @@ Contributors (chronological)
 * `@dodumosu <https://github.com/dodumosu>`_
 * Nate Dellinger `@Nateyo <https://github.com/Nateyo>`_
 * Karthikeyan Singaravelan `@tirkarthi <https://github.com/tirkarthi>`_
+* Sami Salonen `@suola <https://github.com/suola>`_

--- a/src/webargs/falconparser.py
+++ b/src/webargs/falconparser.py
@@ -103,7 +103,7 @@ class FalconParser(core.Parser):
         non-json, even if the request body is parseable as json."""
         if not is_json_request(req) or req.content_length in (None, 0):
             return core.missing
-        body = req.stream.read()
+        body = req.stream.read(req.content_length)
         if body:
             return core.parse_json(body)
         else:

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -1,4 +1,5 @@
 import pytest
+import falcon.testing
 
 from webargs.testing import CommonTestCase
 from tests.apps.falcon_app import create_app
@@ -42,3 +43,10 @@ class TestFalconParser(CommonTestCase):
     def test_parsing_headers(self, testapp):
         res = testapp.get("/echo_headers", headers={"name": "Fred"})
         assert res.json == {"NAME": "Fred"}
+
+    # `falcon.testing.TestClient.simulate_request` parses request with `wsgiref`
+    def test_body_parsing_works_with_simulate(self, testapp):
+        app = self.create_app()
+        client = falcon.testing.TestClient(app)
+        res = client.simulate_post("/echo_json", json={"name": "Fred"},)
+        assert res.json == {"name": "Fred"}

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -45,7 +45,7 @@ class TestFalconParser(CommonTestCase):
         assert res.json == {"NAME": "Fred"}
 
     # `falcon.testing.TestClient.simulate_request` parses request with `wsgiref`
-    def test_body_parsing_works_with_simulate(self, testapp):
+    def test_body_parsing_works_with_simulate(self):
         app = self.create_app()
         client = falcon.testing.TestClient(app)
         res = client.simulate_post("/echo_json", json={"name": "Fred"},)


### PR DESCRIPTION
PEP3333 says:

> A server should allow read() to be called without an argument, and
> return the remainder of the client's input stream.

However, Python standard library `wsgiref` does not allow calling `read`
without arguments. Falcon test client `falcon.testing.TestClient` uses
`wsgiref` - therefore content length should be passed an argument to
`read`.