### PR TITLE
Fix location argument name for docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -48,3 +48,4 @@ Contributors (chronological)
 * Karthikeyan Singaravelan `@tirkarthi <https://github.com/tirkarthi>`_
 * Sami Salonen `@suola <https://github.com/suola>`_
 * Tim Gates `@timgates42 <https://github.com/timgates42>`_
+* Lefteris Karapetsas `@lefterisjp <https://github.com/lefterisjp>`_

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -324,7 +324,7 @@ class Parser:
         :param argmap: Either a `marshmallow.Schema`, a `dict`
             of argname -> `marshmallow.fields.Field` pairs, or a callable
             which accepts a request and returns a `marshmallow.Schema`.
-        :param str locations: Where on the request to load values.
+        :param str location: Where on the request to load values.
         :param bool as_kwargs: Whether to insert arguments as keyword arguments.
         :param callable validate: Validation function that receives the dictionary
             of parsed arguments. If the function returns ``False``, the parser


### PR DESCRIPTION
It seems that the location argument name is wrong in the docs:
https://webargs.readthedocs.io/en/latest/api.html#webargs.core.Parser.use_kwargs

Probably a remnant of the pre v6.0.0 code. This should fix it.