### PR TITLE
Add missing doc, repr, and str for multidictproxy

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,6 +16,14 @@ webargs.fields
 .. automodule:: webargs.fields
     :members: Nested, DelimitedList
 
+
+webargs.multidictproxy
+----------------------
+
+.. automodule:: webargs.multidictproxy
+    :members:
+
+
 webargs.asyncparser
 -------------------
 

--- a/src/webargs/multidictproxy.py
+++ b/src/webargs/multidictproxy.py
@@ -44,6 +44,14 @@ class MultiDictProxy(Mapping):
             return None
         return [val]
 
+    def __str__(self):  # str(proxy) proxies to str(proxy.data)
+        return str(self.data)
+
+    def __repr__(self):
+        return "MultiDictProxy(data={!r}, multiple_keys={!r})".format(
+            self.data, self.multiple_keys
+        )
+
     def __delitem__(self, key):
         del self.data[key]
 


### PR DESCRIPTION
- Add multidictproxy to the full API docs (it was missing)
- Add `__str__` and `__repr__` methods for MultiDictProxy to make debugging with it easier

Having it in the docs also fixes a broken link in the advanced usage doc.

Driven by #485, but this change does not resolve that issue.