### PR TITLE
[WIP] Improve validation error handling for flaskparser

### DIFF
--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -46,13 +46,13 @@ class VerboseError:
             return super().get_description()
         html = []
         for source, errors in self.messages.items():
-            html.append(f"<h2>Errors in {escape(source)}</h2>")
+            html.append("<h2>Errors in {}</h2>".format(escape(source)))
             html.append("<p>")
             if isinstance(errors, dict):
                 for field, message in errors.items():
                     if isinstance(message, list):
                         message = ", ".join(message)
-                    html.append(f"{escape(field)}: {escape(message)}<br>")
+                    html.append("{}: {}<br>".format(escape(field), escape(message)))
             else:
                 html.append(escape(errors))
             html.append("</p>")


### PR DESCRIPTION
This pull request makes the default validation error handling more useable out-of-the-box, and at the same time makes it easier to implement custom error handling. Features are:
* Full information about the validation error on the default error page returned to the client.
* If `error_headers` are passed to the `parse()` method, actually include them in the HTTP response even when using the default error handler.
* Common base class `VerboseError` for all HTTPException instances carrying verbose validation error information, so these errors can specifically be called with constructs like `except VerboseError:` or `@app.errorhandler(VerboseError)`.
* API upwards compatible with the previous behaviour.

Please let me know what you think about this. If you agree to include this patch, I will complete it by adding comments and test cases and updating documentation and examples.