### PR TITLE
Update docs to reflect current handle_error argument names

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -50,3 +50,4 @@ Contributors (chronological)
 * Tim Gates `@timgates42 <https://github.com/timgates42>`_
 * Lefteris Karapetsas `@lefterisjp <https://github.com/lefterisjp>`_
 * Utku Gultopu `@ugultopu <https://github.com/ugultopu>`_
+* Jason Williams `@jaswilli <https://github.com/jaswilli>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -196,7 +196,7 @@ Then decorate that function with :func:`Parser.error_handler <webargs.core.Parse
 
 
     @parser.error_handler
-    def handle_error(error, req, schema, *, status_code, headers):
+    def handle_error(error, req, schema, *, error_status_code, error_headers):
         raise CustomError(error.messages)
 
 Parsing Lists in Query Strings

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -308,6 +308,27 @@ prepared to traverse messages by one additional level. For example:
                 log.debug("bad value for '{}' [{}]: {}".format(field, location, messages))
 
 
+Custom Error Handler Argument Names Changed
+-------------------------------------------
+
+If you define a custom error handler via `@parser.error_handler` the function
+arguments are now keyword-only and `status_code` and `headers` have been renamed
+`error_status_code` and `error_headers`.
+
+.. code-block:: python
+
+    # webargs 5.x
+    @parser.error_handler
+    def custom_handle_error(error, req, schema, status_code, headers):
+        ...
+
+
+    # webargs 6.x
+    @parser.error_handler
+    def custom_handle_error(error, req, schema, *, error_status_code, error_headers):
+        ...
+
+
 Some Functions Take Keyword-Only Arguments Now
 ----------------------------------------------
 
@@ -325,7 +346,7 @@ the changes.
 
 
     # webargs 6.x
-    def handle_error(error, req, schema, *, status_code, headers):
+    def handle_error(error, req, schema, *, error_status_code, error_headers):
         ...
 
 `parser.__init__` methods:

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -434,7 +434,7 @@ class Parser:
 
 
             @parser.error_handler
-            def handle_error(error, req, schema, *, status_code, headers):
+            def handle_error(error, req, schema, *, error_status_code, error_headers):
                 raise CustomError(error.messages)
 
         :param callable func: The error callback to register.


### PR DESCRIPTION
Hi,

I recently did the 5 to 6 upgrade and after following the guide I was still having trouble:

`TypeError: handle_webargs_error() got an unexpected keyword argument 'error_status_code'`

Which after a little digging I realized was because the argument names to the error handler hook (`@parser.error_handler`) had changed and become keyword-only. It seems like the change was mostly overlooked in the places it appears in the docs.

This pull request just updates the docs to update the argument names and call out what's necessary in the 5 -> 6 transition.

Hopefully I didn't overlook anything obvious but I'm happy to be educated if I did.