### PR TITLE
Add ability to pass `unknown` in parse calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,51 @@
 Changelog
 ---------
 
+6.2.0 (Unreleased)
+******************
+
+Features:
+
+* Add a new ``unknown`` parameter to ``Parser.parse``, ``Parser.use_args``, and
+  ``Parser.use_kwargs``. When set, it will be passed to the ``Schema.load``
+  call. If set to ``None`` (the default), no value is passed, so the schema's
+  ``unknown`` behavior is used.
+
+This allows usages like
+
+.. code-block:: python
+
+    import marshmallow as ma
+
+    # marshmallow 3 only, for use of ``unknown`` and ``EXCLUDE``
+    @parser.use_kwargs(
+        {"q1": ma.fields.Int(), "q2": ma.fields.Int()}, location="query", unknown=ma.EXCLUDE
+    )
+    def foo(q1, q2):
+        ...
+
+* Add the ability to set defaults for ``unknown`` on either a Parser instance
+  or Parser class. Set ``Parser.DEFAULT_UNKNOWN`` on a parser class to apply a value
+  to any new parser instances created from that class, or set ``unknown`` during
+  ``Parser`` initialization.
+
+Usages are varied, but include
+
+.. code-block:: python
+
+    import marshmallow as ma
+    from webargs.flaskparser import FlaskParser
+
+    parser = FlaskParser(unknown=ma.INCLUDE)
+
+    # as well as...
+    class MyParser(FlaskParser):
+        DEFAULT_UNKNOWN = ma.INCLUDE
+
+
+    parser = MyParser()
+
+
 6.1.0 (2020-04-05)
 ******************
 

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -101,11 +101,15 @@ class Parser:
     etc.
 
     :param str location: Default location to use for data
+    :param str unknown: Default value for ``unknown`` in ``parse``,
+        ``use_args``, and ``use_kwargs``
     :param callable error_handler: Custom error handler function.
     """
 
     #: Default location to check for data
     DEFAULT_LOCATION = "json"
+    #: Default value to use for 'unknown' on schema load
+    DEFAULT_UNKNOWN = None
     #: The marshmallow Schema class to use when creating new schemas
     DEFAULT_SCHEMA_CLASS = ma.Schema
     #: Default status code to return for validation errors
@@ -125,10 +129,13 @@ class Parser:
         "json_or_form": "load_json_or_form",
     }
 
-    def __init__(self, location=None, *, error_handler=None, schema_class=None):
+    def __init__(
+        self, location=None, *, unknown=None, error_handler=None, schema_class=None
+    ):
         self.location = location or self.DEFAULT_LOCATION
         self.error_callback = _callable_or_raise(error_handler)
         self.schema_class = schema_class or self.DEFAULT_SCHEMA_CLASS
+        self.unknown = unknown or self.DEFAULT_UNKNOWN
 
     def _get_loader(self, location):
         """Get the loader function for the given location.
@@ -222,6 +229,7 @@ class Parser:
         req=None,
         *,
         location=None,
+        unknown=None,
         validate=None,
         error_status_code=None,
         error_headers=None
@@ -236,6 +244,8 @@ class Parser:
             Can be any of the values in :py:attr:`~__location_map__`. By
             default, that means one of ``('json', 'query', 'querystring',
             'form', 'headers', 'cookies', 'files', 'json_or_form')``.
+        :param str unknown: A value to pass for ``unknown`` when calling the
+            schema's ``load`` method (marshmallow 3 only).
         :param callable validate: Validation function or list of validation functions
             that receives the dictionary of parsed arguments. Validator either returns a
             boolean or raises a :exc:`ValidationError`.
@@ -248,6 +258,10 @@ class Parser:
         """
         req = req if req is not None else self.get_default_request()
         location = location or self.location
+        unknown = unknown or self.unknown
+        load_kwargs = (
+            {"unknown": unknown} if MARSHMALLOW_VERSION_INFO[0] >= 3 and unknown else {}
+        )
         if req is None:
             raise ValueError("Must pass req object")
         data = None
@@ -257,7 +271,7 @@ class Parser:
             location_data = self._load_location_data(
                 schema=schema, req=req, location=location
             )
-            result = schema.load(location_data)
+            result = schema.load(location_data, **load_kwargs)
             data = result.data if MARSHMALLOW_VERSION_INFO[0] < 3 else result
             self._validate_arguments(data, validators)
         except ma.exceptions.ValidationError as error:
@@ -307,6 +321,7 @@ class Parser:
         req=None,
         *,
         location=None,
+        unknown=None,
         as_kwargs=False,
         validate=None,
         error_status_code=None,
@@ -325,6 +340,8 @@ class Parser:
             of argname -> `marshmallow.fields.Field` pairs, or a callable
             which accepts a request and returns a `marshmallow.Schema`.
         :param str location: Where on the request to load values.
+        :param str unknown: A value to pass for ``unknown`` when calling the
+            schema's ``load`` method (marshmallow 3 only).
         :param bool as_kwargs: Whether to insert arguments as keyword arguments.
         :param callable validate: Validation function that receives the dictionary
             of parsed arguments. If the function returns ``False``, the parser
@@ -356,6 +373,7 @@ class Parser:
                     argmap,
                     req=req_obj,
                     location=location,
+                    unknown=unknown,
                     validate=validate,
                     error_status_code=error_status_code,
                     error_headers=error_headers,

--- a/src/webargs/pyramidparser.py
+++ b/src/webargs/pyramidparser.py
@@ -113,6 +113,7 @@ class PyramidParser(core.Parser):
         req=None,
         *,
         location=core.Parser.DEFAULT_LOCATION,
+        unknown=None,
         as_kwargs=False,
         validate=None,
         error_status_code=None,
@@ -127,6 +128,8 @@ class PyramidParser(core.Parser):
             which accepts a request and returns a `marshmallow.Schema`.
         :param req: The request object to parse. Pulled off of the view by default.
         :param str location: Where on the request to load values.
+        :param str unknown: A value to pass for ``unknown`` when calling the
+            schema's ``load`` method (marshmallow 3 only).
         :param bool as_kwargs: Whether to insert arguments as keyword arguments.
         :param callable validate: Validation function that receives the dictionary
             of parsed arguments. If the function returns ``False``, the parser
@@ -155,6 +158,7 @@ class PyramidParser(core.Parser):
                     argmap,
                     req=request,
                     location=location,
+                    unknown=unknown,
                     validate=validate,
                     error_status_code=error_status_code,
                     error_headers=error_headers,


### PR DESCRIPTION
This is half of #507 . For the other half, I think we need to wait for 7.0, so we can make a breaking change to the default behavior.

This adds support for passing the `unknown` parameter in two major locations: Parser instantiation, and Parser.parse calls. use_args and use_kwargs are just parse wrappers, and they need to pass it through as well.

It also adds support for a class-level default for unknown, `Parser.DEFAULT_UNKNOWN`, which sets `unknown` for any future parser instances.

Explicit tweaks to handle this were necessary in asyncparser and PyramidParser, due to odd method signatures.

Support is tested in the core tests, but not the various framework tests. (I wanted to add this, but couldn't think of an easy/good way to do it. Suggestions welcome.)

Add a 6.2.0 (Unreleased) changelog entry with detail on this change. The changelog states that we will change the DEFAULT_UNKNOWN default in a future major release. Presumably we'll make it `EXCLUDE`, but I'd like to make it location-dependent if feasible, so I didn't commit to anything in the phrasing.

---

This obsoletes #506 if merged. I like to incorporate people's work if possible, but I don't see a way in this case. I don't think we should make this behavior special for `dict2schema`. I'd rather add a general feature which happens to play nice with `dict2schema`. That way, you get fewer chances for surprising behavioral changes if you replace a dict with a full schema object.

My first attempt at this was much more complex and didn't come together well.
I wanted to have a mapping like
```
{
  "query": EXCLUDE,
  "json": RAISE,
  ...
}
```
but putting this together and making it user-settable was just a lot of work. I'd rather do this, which is simpler, and get it into people's hands if they're having issues moving to 6.x.