### PR TITLE
Fix 1.4.0 docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+version: 2
+python:
+  version: 3.6
+  install:
+    - requirements: docs/requirements.txt

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,3 +1,3 @@
 -r dev-requirements.txt
-aiohttp>=0.21.0
-webtest-aiohttp>=1.1.0
+aiohttp>=0.21.0; python_version >= '3.6'
+webtest-aiohttp>=1.1.0; python_version >= '3.6'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Requirements
-marshmallow
+marshmallow<2.10.3
 
 # Task running
 invoke==0.13.0
@@ -20,7 +20,7 @@ Django>=1.6.5
 bottle>=0.12.3
 tornado>=4.0
 pyramid>=1.5.2
-webapp2>=2.5.2
+webapp2>=2.5.2; python_version < '3.6'
 falcon>=0.3.0
 
 # Syntax checking

--- a/docs/_themes/lucuma/genindex.html
+++ b/docs/_themes/lucuma/genindex.html
@@ -49,7 +49,7 @@
     <table style="width: 100%" class="indextable genindextable"><tr>
       {%- for column in entries|slice(2) if column %}
       <td style="width: 33%" valign="top"><dl>
-        {%- for entryname, (links, subitems) in column %}
+        {%- for entryname, (links, subitems, _) in column %}
           {{ indexentries(entryname, links) }}
           {%- if subitems %}
           <dd><dl>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 -r ../dev-requirements-py3.txt
-sphinx
+sphinx<=1.4
 sphinx-issues==0.2.0


### PR DESCRIPTION
WIP work to fix documentation for 1.4.0. After we merge this, we need to tag the tip of the resulting branch with something like `1.4.0-docs` so we can tell readthedocs to build it and remove the branch.

Please also consider I could go ahead and use the sphinx theme from the latest version of the docs we have so ALL docs look consistent.

Here is how these docs look like
https://webargs-fork.readthedocs.io/en/1.4.0-docs/
compare with 
https://webargs-fork.readthedocs.io/en/1.4.0-docs-last-theme/
where the latest theme was used. I'll send a separate PR so you can consider that too.