### PR TITLE
Add a warning if validation errors are suppressed

### DIFF
--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -269,6 +269,10 @@ class Parser:
                 error_status_code=error_status_code,
                 error_headers=error_headers,
             )
+            warnings.warn(
+                "_on_validation_error hook did not raise an exception and flow "
+                "of control returned to parse(). You may get unexpected results"
+            )
         return data
 
     def get_default_request(self):


### PR DESCRIPTION
I considered having this raise an exception instead, but we can't be certain that the user doesn't know what they're doing in this case. It's conceivable that they have a validation hook which doesn't raise an error and they're prepared for `parse()` to return `None`. However, in that case, it would be beneficial to at least emit a warning if webargs logging is enabled, because this is likely to confuse users.

resolves #518

---

If there's more than we can do, that would be great, but this is all I can think of for that issue. The warning seems reasonable to me (obviously, or I wouldn't submit this PR), but I'm open to discussion.