### PR TITLE
iter(MultiDictProxy) checks if contents are tuples

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+6.1.1 (Unreleased)
+******************
+
+Bug fixes:
+
+* Failure to validate flask headers would produce error data which contained
+  tuples as keys, and was therefore not JSON-serializable. (:issue:`500`)
+  These errors will now extract the headername as the key correctly.
+  Thanks to :user:`shughes-uk` for reporting.
+
 6.1.0 (2020-04-05)
 ******************
 

--- a/src/webargs/multidictproxy.py
+++ b/src/webargs/multidictproxy.py
@@ -62,7 +62,13 @@ class MultiDictProxy(Mapping):
         return getattr(self.data, name)
 
     def __iter__(self):
-        return iter(self.data)
+        for x in iter(self.data):
+            # special case for header dicts which produce an iterator of tuples
+            # instead of an iterator of strings
+            if isinstance(x, tuple):
+                yield x[0]
+            else:
+                yield x
 
     def __contains__(self, x):
         return x in self.data

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -126,6 +126,14 @@ def echo_headers():
     return J(parser.parse(hello_exclude_schema, location="headers"))
 
 
+@app.route("/echo_headers_raising")
+@use_args(HelloSchema(**strict_kwargs), location="headers")
+def echo_headers_raising(args):
+    # as above, but in this case, don't use the exclude schema (so unexpected
+    # headers will raise errors)
+    return J(args)
+
+
 @app.route("/echo_cookie")
 def echo_cookie():
     return J(parser.parse(hello_args, request, location="cookies"))


### PR DESCRIPTION
Specifically in order to handle headers more gracefully, MultiDictProxy needs to be careful about how it exposes `__iter__`.
Marshmallow gets a list of keys in the data it's loading by calling `set(data)`, which implicitly calls `iter()`. And MultiDictProxy was naively proxying that method to the underlying object's `__iter__`.

However, for Flask Headers and potentially other specialized request objects, `iter()` does not produce an iterator over keys, but over some other type. In the case of Flask Headers, the type produced is a tuple of (key, value).

Rather than trying to make MultiDictProxy aware of all of the dict-like types it might be handling, simply wrap the `iter()` call in a loop which checks if objects are tuples. If they are, pop the first element. In the case of headers, at least, that is the key.

This can definitely be made to fail on oddly-constructed underlying data. e.g. If you define a type where iter yields an empty tuple, this will blow up. However, no known real data from frameworks is shaped that way.

fixes #500

-----

It wasn't obvious to me what the right way to wrap `__iter__` was, so this is basically the simplest thing that came to mind. If there's a better way, or some error cases we want to handle, I'm open to that.