### PR TITLE
[7.x] ValueError if error handler does not reraise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,12 @@ Usages are varied, but include
 
     parser = MyParser()
 
+Changes:
+
+* Registered `error_handler` callbacks are required to raise an exception.
+  If a handler is invoked and no exception is raised, `webargs` will raise
+  a `ValueError` (:issue:`527`)
+
 6.1.1 (2020-09-08)
 ******************
 

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -283,10 +283,9 @@ class Parser:
                 error_status_code=error_status_code,
                 error_headers=error_headers,
             )
-            warnings.warn(
-                "_on_validation_error hook did not raise an exception and flow "
-                "of control returned to parse(). You may get unexpected results"
-            )
+            raise ValueError(
+                "_on_validation_error hook did not raise an exception"
+            ) from error
         return data
 
     def get_default_request(self):


### PR DESCRIPTION
Note: I'm opening this as a PR against the 7.0-dev branch. I realized I should make sure any changes I'm trying to slate for v7.0 go through proper review.

In 6.x this was only a warning. Now, if someone defines an error handler which does not raise an exception, webargs will raise a
ValueError. This prevents use_args/use_kwargs/parse from returning malformed or unexpected data if an error handler fires but does not raise an exception.

Several tests needed tweaking to handle this, as they defined handlers which did not raise errors.

closes #527