### PR TITLE
[7.x] Refactor support for 'unknown' with location map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,10 +27,11 @@ Refactoring:
 
 Features:
 
-* Add a new ``unknown`` parameter to ``Parser.parse``, ``Parser.use_args``, and
-  ``Parser.use_kwargs``. When set, it will be passed to the ``Schema.load``
-  call. If set to ``None`` (the default), no value is passed, so the schema's
-  ``unknown`` behavior is used.
+* Add ``unknown`` as a parameter to ``Parser.parse``, ``Parser.use_args``, and
+  ``Parser.use_kwargs``, or to parser instantiation. When set, it will be passed
+  to ``Schema.load``. When not set, the value passed will depend on the parser's
+  settings. If set to ``None``, the schema's default behavior will be used (i.e.
+  no value is passed to ``Schema.load``) and parser settings will be ignored.
 
 This allows usages like
 
@@ -45,10 +46,10 @@ This allows usages like
     def foo(q1, q2):
         ...
 
-* Add the ability to set defaults for ``unknown`` on either a Parser instance
-  or Parser class. Set ``Parser.DEFAULT_UNKNOWN`` on a parser class to apply a value
-  to any new parser instances created from that class, or set ``unknown`` during
-  ``Parser`` initialization.
+* Defaults for ``unknown`` may be customized on parser classes via
+  ``Parser.DEFAULT_UNKNOWN_BY_LOCATION``, which maps location names to values
+  to use, and ``Parser.DEFAULT_UNKNOWN``, which is used when a location is not
+  found in ``DEFAULT_UNKNOWN_BY_LOCATION``.
 
 Usages are varied, but include
 
@@ -61,10 +62,24 @@ Usages are varied, but include
 
     # as well as...
     class MyParser(FlaskParser):
-        DEFAULT_UNKNOWN = ma.INCLUDE
+        DEFAULT_UNKNOWN_BY_LOCATION = {"query": ma.INCLUDE}
 
 
     parser = MyParser()
+
+Setting the ``unknown`` value for a Parser instance has higher precedence. So
+
+.. code-block:: python
+
+    parser = MyParser(unknown=ma.RAISE)
+
+will always pass ``RAISE``, even when the location is ``query``.
+
+* By default, webargs will pass ``unknown=EXCLUDE`` for all locations except
+  for request bodies (``json``, ``form``, and ``json_or_form``) and path
+  parameters. Request bodies and path parameters will pass ``unknown=RAISE``.
+  This behavior is defined by the default values for ``DEFAULT_UNKNOWN`` and
+  ``DEFAULT_UNKNOWN_BY_LOCATION``.
 
 Changes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,8 +27,8 @@ Refactoring:
 
 Features:
 
-* Add ``unknown`` as a parameter to ``Parser.parse``, ``Parser.use_args``, and
-  ``Parser.use_kwargs``, or to parser instantiation. When set, it will be passed
+* Add ``unknown`` as a parameter to ``Parser.parse``, ``Parser.use_args``,
+  ``Parser.use_kwargs``, and parser instantiation. When set, it will be passed
   to ``Schema.load``. When not set, the value passed will depend on the parser's
   settings. If set to ``None``, the schema's default behavior will be used (i.e.
   no value is passed to ``Schema.load``) and parser settings will be ignored.
@@ -48,8 +48,7 @@ This allows usages like
 
 * Defaults for ``unknown`` may be customized on parser classes via
   ``Parser.DEFAULT_UNKNOWN_BY_LOCATION``, which maps location names to values
-  to use, and ``Parser.DEFAULT_UNKNOWN``, which is used when a location is not
-  found in ``DEFAULT_UNKNOWN_BY_LOCATION``.
+  to use.
 
 Usages are varied, but include
 
@@ -57,8 +56,6 @@ Usages are varied, but include
 
     import marshmallow as ma
     from webargs.flaskparser import FlaskParser
-
-    parser = FlaskParser(unknown=ma.INCLUDE)
 
     # as well as...
     class MyParser(FlaskParser):
@@ -78,7 +75,7 @@ will always pass ``RAISE``, even when the location is ``query``.
 * By default, webargs will pass ``unknown=EXCLUDE`` for all locations except
   for request bodies (``json``, ``form``, and ``json_or_form``) and path
   parameters. Request bodies and path parameters will pass ``unknown=RAISE``.
-  This behavior is defined by the default values for ``DEFAULT_UNKNOWN`` and
+  This behavior is defined by the default value for
   ``DEFAULT_UNKNOWN_BY_LOCATION``.
 
 Changes:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -128,6 +128,113 @@ When you need more flexibility in defining input schemas, you can pass a marshma
         # ...
 
 
+Setting `unknown`
+-----------------
+
+webargs supports several ways of setting and passing the `unknown` parameter
+for `handling unknown fields <https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields>`_.
+
+You can pass `unknown=...` as a parameter to any of
+`Parser.parse <webargs.core.Parser.parse>`,
+`Parser.use_args <webargs.core.Parser.use_args>`, and
+`Parser.use_kwargs <webargs.core.Parser.use_kwargs>`.
+
+
+.. note::
+
+    The `unknown` value is passed to the schema's `load()` call. It therefore
+    only applies to the top layer when nesting is used. To control `unknown` at
+    multiple layers of a nested schema, you must use other mechanisms, like
+    the `unknown` argument to `fields.Nested`.
+
+Default `unknown`
++++++++++++++++++
+
+By default, webargs will pass `unknown=marshmallow.EXCLUDE` except when the
+location is `json`, `form`, or `json_or_form`. In those cases, it uses
+`unknown=marshmallow.RAISE` instead.
+
+You can change these defaults by overriding `DEFAULT_UNKNOWN_BY_LOCATION` and
+`DEFAULT_UNKNOWN`. The first is a mapping of locations to values to pass, and
+the second is the fallback value used if the location is not included in the
+map.
+
+You can also define a default at parser instantiation, which will take
+precedence over these defaults.
+
+For example,
+
+.. code-block:: python
+
+    from flask import Flask
+    from marshmallow import EXCLUDE, INCLUDE, fields
+    from webargs.flaskparser import FlaskParser
+
+    app = Flask(__name__)
+
+
+    class Parser(FlaskParser):
+        DEFAULT_UNKNOWN = INCLUDE
+        DEFAULT_UNKNOWN_BY_LOCATION = {"query": EXCLUDE}
+
+
+    parser = Parser()
+
+
+    # location is "query", which is listed in DEFAULT_UNKNOWN_BY_LOCATION,
+    # so EXCLUDE will be used
+    @app.route("/", methods=["GET"])
+    @parser.use_args({"foo": fields.Int()}, location="query")
+    def get(self, args):
+        return f"foo x 2 = {args['foo'] * 2}"
+
+
+    # location is "json", which is not in DEFAULT_UNKNOWN_BY_LOCATION,
+    # so the parser's default value, `INCLUDE`, will be used
+    @app.route("/", methods=["POST"])
+    @parser.use_args({"foo": fields.Int(), "bar": fields.Int()}, location="json")
+    def post(self, args):
+        unexpected_args = [k for k in args.keys() if k not in ("foo", "bar")]
+        return f"foo x bar = {args['foo'] * args['bar']}; unexpected args={unexpected_args}"
+
+
+Using Schema-Specfied `unknown`
++++++++++++++++++++++++++++++++
+
+If you wish to use the value of `unknown` specified by a schema, simply pass
+``unknown=None``. This will disable webargs' automatic passing of values for
+``unknown``. For example,
+
+.. code-block:: python
+
+    from flask import Flask
+    from marshmallow import Schema, fields, EXCLUDE, missing
+    from webargs.flaskparser import use_args
+
+
+    class RectangleSchema(Schema):
+        length = fields.Float()
+        width = fields.Float()
+
+        class Meta:
+            unknown = EXCLUDE
+
+
+    app = Flask(__name__)
+
+    # because unknown=None was passed, no value is passed during schema loading
+    # as a result, the schema's behavior (EXCLUDE) is used
+    @app.route("/", methods=["POST"])
+    @use_args(RectangleSchema(), location="json", unknown=None)
+    def get(self, args):
+        return f"area = {args['length'] * args['width']}"
+
+
+You can also set ``unknown=None`` when instantiating a parser, or set
+``DEFAULT_UNKNOWN = None`` to make this behavior the default for a parser
+class.
+
+
 When to avoid `use_kwargs`
 --------------------------
 

--- a/src/webargs/aiohttpparser.py
+++ b/src/webargs/aiohttpparser.py
@@ -27,7 +27,7 @@ import typing
 from aiohttp import web
 from aiohttp.web import Request
 from aiohttp import web_exceptions
-from marshmallow import Schema, ValidationError
+from marshmallow import Schema, ValidationError, RAISE
 
 from webargs import core
 from webargs.core import json
@@ -72,6 +72,11 @@ del _find_exceptions
 class AIOHTTPParser(AsyncParser):
     """aiohttp request argument parser."""
 
+    DEFAULT_UNKNOWN_BY_LOCATION = {
+        "match_info": RAISE,
+        "path": RAISE,
+        **core.Parser.DEFAULT_UNKNOWN_BY_LOCATION,
+    }
     __location_map__ = dict(
         match_info="load_match_info",
         path="load_match_info",

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -45,9 +45,7 @@ class AsyncParser(core.Parser):
             else (
                 self.unknown
                 if self.unknown != core._UNKNOWN_DEFAULT_PARAM
-                else self.DEFAULT_UNKNOWN_BY_LOCATION.get(
-                    location, self.DEFAULT_UNKNOWN
-                )
+                else self.DEFAULT_UNKNOWN_BY_LOCATION.get(location)
             )
         )
         load_kwargs = {"unknown": unknown}

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -28,7 +28,7 @@ class AsyncParser(core.Parser):
         req: Request = None,
         *,
         location: str = None,
-        unknown: str = None,
+        unknown: str = core._UNKNOWN_DEFAULT_PARAM,
         validate: Validate = None,
         error_status_code: typing.Union[int, None] = None,
         error_headers: typing.Union[typing.Mapping[str, str], None] = None
@@ -39,7 +39,17 @@ class AsyncParser(core.Parser):
         """
         req = req if req is not None else self.get_default_request()
         location = location or self.location
-        unknown = unknown or self.unknown
+        unknown = (
+            unknown
+            if unknown != core._UNKNOWN_DEFAULT_PARAM
+            else (
+                self.unknown
+                if self.unknown != core._UNKNOWN_DEFAULT_PARAM
+                else self.DEFAULT_UNKNOWN_BY_LOCATION.get(
+                    location, self.DEFAULT_UNKNOWN
+                )
+            )
+        )
         load_kwargs = {"unknown": unknown}
         if req is None:
             raise ValueError("Must pass req object")
@@ -113,7 +123,7 @@ class AsyncParser(core.Parser):
         req: typing.Optional[Request] = None,
         *,
         location: str = None,
-        unknown=None,
+        unknown=core._UNKNOWN_DEFAULT_PARAM,
         as_kwargs: bool = False,
         validate: Validate = None,
         error_status_code: typing.Optional[int] = None,

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -111,12 +111,16 @@ class Parser:
     #: Default location to check for data
     DEFAULT_LOCATION = "json"
     #: Default value to use for 'unknown' on schema load
-    DEFAULT_UNKNOWN = ma.EXCLUDE
-    #: per-location default for 'unknown'
+    #  on a per-location basis
     DEFAULT_UNKNOWN_BY_LOCATION = {
         "json": ma.RAISE,
         "form": ma.RAISE,
         "json_or_form": ma.RAISE,
+        "querystring": ma.EXCLUDE,
+        "query": ma.EXCLUDE,
+        "headers": ma.EXCLUDE,
+        "cookies": ma.EXCLUDE,
+        "files": ma.EXCLUDE,
     }
     #: The marshmallow Schema class to use when creating new schemas
     DEFAULT_SCHEMA_CLASS = ma.Schema
@@ -267,16 +271,14 @@ class Parser:
         """
         req = req if req is not None else self.get_default_request()
         location = location or self.location
-        # precedence order: explicit, instance setting, default per location, default
+        # precedence order: explicit, instance setting, default per location
         unknown = (
             unknown
             if unknown != _UNKNOWN_DEFAULT_PARAM
             else (
                 self.unknown
                 if self.unknown != _UNKNOWN_DEFAULT_PARAM
-                else self.DEFAULT_UNKNOWN_BY_LOCATION.get(
-                    location, self.DEFAULT_UNKNOWN
-                )
+                else self.DEFAULT_UNKNOWN_BY_LOCATION.get(location)
             )
         )
         load_kwargs = {"unknown": unknown} if unknown else {}

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -23,6 +23,8 @@ Example: ::
 import flask
 from werkzeug.exceptions import HTTPException
 
+import marshmallow as ma
+
 from webargs import core
 from webargs.multidictproxy import MultiDictProxy
 
@@ -48,6 +50,11 @@ def is_json_request(req):
 class FlaskParser(core.Parser):
     """Flask request argument parser."""
 
+    DEFAULT_UNKNOWN_BY_LOCATION = {
+        "view_args": ma.RAISE,
+        "path": ma.RAISE,
+        **core.Parser.DEFAULT_UNKNOWN_BY_LOCATION,
+    }
     __location_map__ = dict(
         view_args="load_view_args",
         path="load_view_args",

--- a/src/webargs/pyramidparser.py
+++ b/src/webargs/pyramidparser.py
@@ -30,6 +30,8 @@ from collections.abc import Mapping
 from webob.multidict import MultiDict
 from pyramid.httpexceptions import exception_response
 
+import marshmallow as ma
+
 from webargs import core
 from webargs.core import json
 from webargs.multidictproxy import MultiDictProxy
@@ -42,6 +44,11 @@ def is_json_request(req):
 class PyramidParser(core.Parser):
     """Pyramid request argument parser."""
 
+    DEFAULT_UNKNOWN_BY_LOCATION = {
+        "matchdict": ma.RAISE,
+        "path": ma.RAISE,
+        **core.Parser.DEFAULT_UNKNOWN_BY_LOCATION,
+    }
     __location_map__ = dict(
         matchdict="load_matchdict",
         path="load_matchdict",

--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -75,7 +75,9 @@ async def echo_use_args_validated(request, args):
 
 
 async def echo_ignoring_extra_data(request):
-    return json_response(await parser.parse(hello_exclude_schema, request))
+    return json_response(
+        await parser.parse(hello_exclude_schema, request, unknown=None)
+    )
 
 
 async def echo_multi(request):
@@ -124,7 +126,7 @@ async def always_error(request):
 
 
 async def echo_headers(request):
-    parsed = await parser.parse(hello_exclude_schema, request, location="headers")
+    parsed = await parser.parse(hello_args, request, location="headers")
     return json_response(parsed)
 
 

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -65,7 +65,7 @@ def echo_use_args_validated(args):
 
 @app.route("/echo_ignoring_extra_data", method=["POST"])
 def echo_json_ignore_extra_data():
-    return parser.parse(hello_exclude_schema)
+    return parser.parse(hello_exclude_schema, unknown=None)
 
 
 @app.route(
@@ -123,9 +123,7 @@ def always_error():
 
 @app.route("/echo_headers")
 def echo_headers():
-    # the "exclude schema" must be used in this case because WSGI headers may
-    # be populated with many fields not sent by the caller
-    return parser.parse(hello_exclude_schema, request, location="headers")
+    return parser.parse(hello_args, request, location="headers")
 
 
 @app.route("/echo_cookie")

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -73,7 +73,7 @@ def echo_use_args_validated(args):
 
 @handle_view_errors
 def echo_ignoring_extra_data(request):
-    return json_response(parser.parse(hello_exclude_schema, request))
+    return json_response(parser.parse(hello_exclude_schema, request, unknown=None))
 
 
 @handle_view_errors
@@ -125,9 +125,7 @@ def always_error(request):
 
 @handle_view_errors
 def echo_headers(request):
-    return json_response(
-        parser.parse(hello_exclude_schema, request, location="headers")
-    )
+    return json_response(parser.parse(hello_args, request, location="headers"))
 
 
 @handle_view_errors

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -67,7 +67,7 @@ class EchoUseArgsValidated:
 
 class EchoJSONIgnoreExtraData:
     def on_post(self, req, resp):
-        resp.body = json.dumps(parser.parse(hello_exclude_schema, req))
+        resp.body = json.dumps(parser.parse(hello_exclude_schema, req, unknown=None))
 
 
 class EchoMulti:
@@ -118,9 +118,7 @@ class EchoHeaders:
         class HeaderSchema(ma.Schema):
             NAME = fields.Str(missing="World")
 
-        resp.body = json.dumps(
-            parser.parse(HeaderSchema(unknown=ma.EXCLUDE), req, location="headers")
-        )
+        resp.body = json.dumps(parser.parse(HeaderSchema(), req, location="headers"))
 
 
 class EchoCookie:

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -21,9 +21,6 @@ class HelloSchema(ma.Schema):
 
 hello_many_schema = HelloSchema(many=True)
 
-# variant which ignores unknown fields
-hello_exclude_schema = HelloSchema(unknown=ma.EXCLUDE)
-
 app = Flask(__name__)
 app.config.from_object(TestAppConfig)
 
@@ -64,7 +61,7 @@ def echo_use_args_validated(args):
 
 @app.route("/echo_ignoring_extra_data", methods=["POST"])
 def echo_json_ignore_extra_data():
-    return J(parser.parse(hello_exclude_schema))
+    return J(parser.parse(hello_args, unknown=ma.EXCLUDE))
 
 
 @app.route("/echo_use_kwargs", methods=["GET"])
@@ -117,16 +114,14 @@ def error():
 
 @app.route("/echo_headers")
 def echo_headers():
-    # the "exclude schema" must be used in this case because WSGI headers may
-    # be populated with many fields not sent by the caller
-    return J(parser.parse(hello_exclude_schema, location="headers"))
+    return J(parser.parse(hello_args, location="headers"))
 
 
+# as above, but in this case, turn off the default `EXCLUDE` behavior for
+# `headers`, so that errors will be raised
 @app.route("/echo_headers_raising")
-@use_args(HelloSchema(), location="headers")
+@use_args(HelloSchema(), location="headers", unknown=None)
 def echo_headers_raising(args):
-    # as above, but in this case, don't use the exclude schema (so unexpected
-    # headers will raise errors)
     return J(args)
 
 

--- a/tests/apps/pyramid_app.py
+++ b/tests/apps/pyramid_app.py
@@ -50,7 +50,7 @@ def echo_json_or_form(request):
 
 def echo_json_ignore_extra_data(request):
     try:
-        return parser.parse(hello_exclude_schema, request)
+        return parser.parse(hello_exclude_schema, request, unknown=None)
     except json.JSONDecodeError:
         error = HTTPBadRequest()
         error.body = json.dumps(["Invalid JSON."]).encode("utf-8")
@@ -114,7 +114,7 @@ def always_error(request):
 
 
 def echo_headers(request):
-    return parser.parse(hello_exclude_schema, request, location="headers")
+    return parser.parse(hello_args, request, location="headers")
 
 
 def echo_cookie(request):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,7 +114,6 @@ def test_parse(parser, web_request):
         "parse_call",
         "parser_default",
         "parser_class_default",
-        "parser_class_location_default",
     ],
 )
 def test_parse_with_unknown_behavior_specified(parser, web_request, set_location):
@@ -142,14 +141,6 @@ def test_parse_with_unknown_behavior_specified(parser, web_request, set_location
         elif set_location == "parser_class_default":
 
             class CustomParser(MockRequestParser):
-                DEFAULT_UNKNOWN = value
-                DEFAULT_UNKNOWN_BY_LOCATION = {}
-
-            return CustomParser().parse(CustomSchema(), web_request)
-        elif set_location == "parser_class_location_default":
-
-            class CustomParser(MockRequestParser):
-                DEFAULT_UNKNOWN = None
                 DEFAULT_UNKNOWN_BY_LOCATION = {"json": value}
 
             return CustomParser().parse(CustomSchema(), web_request)
@@ -204,7 +195,6 @@ def test_parse_with_default_unknown_cleared_uses_schema_value(
     if clear_method == "custom_class":
 
         class CustomParser(MockRequestParser):
-            DEFAULT_UNKNOWN = None
             DEFAULT_UNKNOWN_BY_LOCATION = {}
 
         parser = CustomParser()
@@ -213,7 +203,6 @@ def test_parse_with_default_unknown_cleared_uses_schema_value(
     elif clear_method == "both":
         # setting things in multiple ways should not result in errors
         class CustomParser(MockRequestParser):
-            DEFAULT_UNKNOWN = None
             DEFAULT_UNKNOWN_BY_LOCATION = {}
 
         parser = CustomParser(unknown=None)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,7 +109,13 @@ def test_parse(parser, web_request):
 
 @pytest.mark.parametrize(
     "set_location",
-    ["schema_instance", "parse_call", "parser_default", "parser_class_default"],
+    [
+        "schema_instance",
+        "parse_call",
+        "parser_default",
+        "parser_class_default",
+        "parser_class_location_default",
+    ],
 )
 def test_parse_with_unknown_behavior_specified(parser, web_request, set_location):
     web_request.json = {"username": 42, "password": 42, "fjords": 42}
@@ -121,7 +127,11 @@ def test_parse_with_unknown_behavior_specified(parser, web_request, set_location
     def parse_with_desired_behavior(value):
         if set_location == "schema_instance":
             if value is not None:
-                return parser.parse(CustomSchema(unknown=value), web_request)
+                # pass 'unknown=None' to parse() in order to indicate that the
+                # schema setting should be respected
+                return parser.parse(
+                    CustomSchema(unknown=value), web_request, unknown=None
+                )
             else:
                 return parser.parse(CustomSchema(), web_request)
         elif set_location == "parse_call":
@@ -133,6 +143,14 @@ def test_parse_with_unknown_behavior_specified(parser, web_request, set_location
 
             class CustomParser(MockRequestParser):
                 DEFAULT_UNKNOWN = value
+                DEFAULT_UNKNOWN_BY_LOCATION = {}
+
+            return CustomParser().parse(CustomSchema(), web_request)
+        elif set_location == "parser_class_location_default":
+
+            class CustomParser(MockRequestParser):
+                DEFAULT_UNKNOWN = None
+                DEFAULT_UNKNOWN_BY_LOCATION = {"json": value}
 
             return CustomParser().parse(CustomSchema(), web_request)
         else:
@@ -170,6 +188,46 @@ def test_parse_with_explicit_unknown_overrides_schema(parser, web_request):
     ret = parser.parse(CustomSchema(unknown=RAISE), web_request, unknown=EXCLUDE)
     assert {"username": 42, "password": 42} == ret
     ret = parser.parse(CustomSchema(unknown=RAISE), web_request, unknown=INCLUDE)
+    assert {"username": 42, "password": 42, "fjords": 42} == ret
+
+
+@pytest.mark.parametrize("clear_method", ["custom_class", "instance_setting", "both"])
+def test_parse_with_default_unknown_cleared_uses_schema_value(
+    parser, web_request, clear_method
+):
+    web_request.json = {"username": 42, "password": 42, "fjords": 42}
+
+    class CustomSchema(Schema):
+        username = fields.Field()
+        password = fields.Field()
+
+    if clear_method == "custom_class":
+
+        class CustomParser(MockRequestParser):
+            DEFAULT_UNKNOWN = None
+            DEFAULT_UNKNOWN_BY_LOCATION = {}
+
+        parser = CustomParser()
+    elif clear_method == "instance_setting":
+        parser = MockRequestParser(unknown=None)
+    elif clear_method == "both":
+        # setting things in multiple ways should not result in errors
+        class CustomParser(MockRequestParser):
+            DEFAULT_UNKNOWN = None
+            DEFAULT_UNKNOWN_BY_LOCATION = {}
+
+        parser = CustomParser(unknown=None)
+    else:
+        raise NotImplementedError
+
+    with pytest.raises(ValidationError, match="Unknown field."):
+        parser.parse(CustomSchema(), web_request)
+    with pytest.raises(ValidationError, match="Unknown field."):
+        parser.parse(CustomSchema(unknown=RAISE), web_request)
+
+    ret = parser.parse(CustomSchema(unknown=EXCLUDE), web_request)
+    assert {"username": 42, "password": 42} == ret
+    ret = parser.parse(CustomSchema(unknown=INCLUDE), web_request)
     assert {"username": 42, "password": 42, "fjords": 42} == ret
 
 


### PR DESCRIPTION
Based on the suggestion in #514, this is my attempt at putting together what I think is ideal behavior for webargs: we have sensible defaults for `unknown` based on locations, but it's easy to opt-out by just setting `unknown=None` or overriding the defaults.
It should be possible to use the `query`, `headers`, and similar locations out of the box without issue. By passing `unknown=EXCLUDE` for these locations, that is achieved.

This introduces a new Parser-class variable, `DEFAULT_UNKNOWN_BY_LOCATION`, which maps location names to
`unknown` values. It populates that and `DEFAULT_UNKNOWN` to pass `EXCLUDE` in the general case and `RAISE` for request bodies.

The new behavior is layered and defined with lower precedence than `Parser.unknown` or the `unknown` parameter on parse calls. In order to implement this and allow users to opt *out* of the behavior (i.e. in order to use schema-defined values), the way these values are set is subtly changed. Instead of having a default value of `None`, parse calls and parser `__init__` have a default of `unknown="_default"`. When that value is detected, the various layers of defaults (DEFAULT_UNKNOWN and DEFAULT_UNKNOWN_BY_LOCATION) are applied. However, if a user passes `None`, that will take effect with the meaning "do not pass a value for `unknown`".

The changelog has been updated significantly in order to handle this and a new section of the advanced usage docs covers the behavior.

If this seems good, I'd like to switch the branches around so that we have a 6.x maintenance branch and 7.0 is in progress in `dev`, as @lafrech suggested. I think we could release this as `7.0.0b1`, if that sounds acceptable. And then other work (like dropping 3.5) can happen during the 7.0 beta period.