### PR TITLE
Switch FalconParser to using 'media' by default

### DIFF
--- a/src/webargs/falconparser.py
+++ b/src/webargs/falconparser.py
@@ -3,6 +3,8 @@
 import falcon
 from falcon.util.uri import parse_query_string
 
+import marshmallow as ma
+
 from webargs import core
 from webargs.multidictproxy import MultiDictProxy
 
@@ -69,7 +71,21 @@ class HTTPError(falcon.HTTPError):
 
 
 class FalconParser(core.Parser):
-    """Falcon request argument parser."""
+    """Falcon request argument parser.
+
+    Defaults to using the `media` location. See :py:meth:`~FalconParser.load_media` for
+    details on the media location."""
+
+    # by default, Falcon will use the 'media' location to load data
+    #
+    # this effectively looks the same as loading JSON data by default, but if
+    # you add a handler for a different media type to Falcon, webargs will
+    # automatically pick up on that capability
+    DEFAULT_LOCATION = "media"
+    DEFAULT_UNKNOWN_BY_LOCATION = dict(
+        media=ma.RAISE, **core.Parser.DEFAULT_UNKNOWN_BY_LOCATION
+    )
+    __location_map__ = dict(media="load_media", **core.Parser.__location_map__)
 
     # Note on the use of MultiDictProxy throughout:
     # Falcon parses query strings and form values into ordinary dicts, but with
@@ -94,6 +110,25 @@ class FalconParser(core.Parser):
         if form is core.missing:
             return form
         return MultiDictProxy(form, schema)
+
+    def load_media(self, req, schema):
+        """Return data unpacked and parsed by one of Falcon's media handlers.
+        By default, Falcon only handles JSON payloads.
+
+        To configure additional media handlers, see the
+        `Falcon documentation on media types`__.
+
+        .. _FalconMedia: https://falcon.readthedocs.io/en/stable/api/media.html
+        __ FalconMedia_
+
+        .. note::
+
+            The request stream will be read and left at EOF.
+        """
+        # if there is no body, return missing instead of erroring
+        if req.content_length in (None, 0):
+            return core.missing
+        return req.media
 
     def _raw_load_json(self, req):
         """Return a json payload from the request for the core parser's load_json

--- a/src/webargs/testing.py
+++ b/src/webargs/testing.py
@@ -62,9 +62,6 @@ class CommonTestCase:
     def test_parse_querystring_default(self, testapp):
         assert testapp.get("/echo").json == {"name": "World"}
 
-    def test_parse_json_default(self, testapp):
-        assert testapp.post_json("/echo_json", {}).json == {"name": "World"}
-
     def test_parse_json_with_charset(self, testapp):
         res = testapp.post(
             "/echo_json",

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -37,6 +37,12 @@ class EchoJSON:
         resp.body = json.dumps(parsed)
 
 
+class EchoMedia:
+    def on_post(self, req, resp):
+        parsed = parser.parse(hello_args, req, location="media")
+        resp.body = json.dumps(parsed)
+
+
 class EchoJSONOrForm:
     def on_post(self, req, resp):
         parsed = parser.parse(hello_args, req, location="json_or_form")
@@ -161,6 +167,7 @@ def create_app():
     app.add_route("/echo", Echo())
     app.add_route("/echo_form", EchoForm())
     app.add_route("/echo_json", EchoJSON())
+    app.add_route("/echo_media", EchoMedia())
     app.add_route("/echo_json_or_form", EchoJSONOrForm())
     app.add_route("/echo_use_args", EchoUseArgs())
     app.add_route("/echo_use_kwargs", EchoUseKwargs())

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -16,28 +16,47 @@ class TestFalconParser(CommonTestCase):
     def test_use_args_hook(self, testapp):
         assert testapp.get("/echo_use_args_hook?name=Fred").json == {"name": "Fred"}
 
+    def test_parse_media(self, testapp):
+        assert testapp.post_json("/echo_media", {"name": "Fred"}).json == {
+            "name": "Fred"
+        }
+
+    def test_parse_media_missing(self, testapp):
+        assert testapp.post("/echo_media", "").json == {"name": "World"}
+
+    def test_parse_media_empty(self, testapp):
+        assert testapp.post_json("/echo_media", {}).json == {"name": "World"}
+
+    def test_parse_media_error_unexpected_int(self, testapp):
+        res = testapp.post_json("/echo_media", 1, expect_errors=True)
+        assert res.status_code == 422
+
     # https://github.com/marshmallow-code/webargs/issues/427
-    def test_parse_json_with_nonutf8_chars(self, testapp):
+    @pytest.mark.parametrize("path", ["/echo_json", "/echo_media"])
+    def test_parse_json_with_nonutf8_chars(self, testapp, path):
         res = testapp.post(
-            "/echo_json",
+            path,
             b"\xfe",
             headers={"Accept": "application/json", "Content-Type": "application/json"},
             expect_errors=True,
         )
 
         assert res.status_code == 400
-        assert res.json["errors"] == {"json": ["Invalid JSON body."]}
+        if path.endswith("json"):
+            assert res.json["errors"] == {"json": ["Invalid JSON body."]}
 
     # https://github.com/sloria/webargs/issues/329
-    def test_invalid_json(self, testapp):
+    @pytest.mark.parametrize("path", ["/echo_json", "/echo_media"])
+    def test_invalid_json(self, testapp, path):
         res = testapp.post(
-            "/echo_json",
+            path,
             '{"foo": "bar", }',
             headers={"Accept": "application/json", "Content-Type": "application/json"},
             expect_errors=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"] == {"json": ["Invalid JSON body."]}
+        if path.endswith("json"):
+            assert res.json["errors"] == {"json": ["Invalid JSON body."]}
 
     # Falcon converts headers to all-caps
     def test_parsing_headers(self, testapp):


### PR DESCRIPTION
Add a new location to the FalconParser, `media` (handler is `load_media`), and sets it as the default for this parser.

`media` refers to `Request.media` as offered by Falcon, which is a pluggable part of the Falcon request which deserializes data. By
default, it only deserializes JSON paylaods, but you can register additional "handlers", paired with content-types, and it will appropriately map content-type headers to handlers. Falcon docs leave it unclear how exactly the json loading behaves if there is no appropriate payload, so we test these cases explicitly.

New tests for `media` mirror several of the existing JSON tests, but we can skip several cases, like handling of vendor media types (because `media` doesn't do that out of the box). Additionally, we need to avoid expecting webargs-specific error messages in some cases because they won't be returned when error handling is being done by Falcon.

Docs for FalconParser now link to Falcon docs for those who want to customize `media`.

Minor fix slipped in here: `test_parse_json_default` and `test_parse_json_empty` were duplicate tests, so I've removed one.

closes #253