### PR TITLE
Remove `--keep-mock` flag from `pyupgrade`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v2.7.3
   hooks:
   - id: pyupgrade
-    args: ["--py36-plus", "--keep-mock"]
+    args: ["--py36-plus"]
 - repo: https://github.com/psf/black
   rev: 20.8b1
   hooks:


### PR DESCRIPTION
We aren't using the mock backport anymore, so this flag does nothing.