### PR TITLE
Add support for headers to DjangoParser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 FRAMEWORKS = [
     "Flask>=0.12.2",
-    "Django>=1.11.16",
+    "Django>=2.2.0",
     "bottle>=0.12.13",
     "tornado>=4.5.2",
     "pyramid>=1.9.1",

--- a/src/webargs/djangoparser.py
+++ b/src/webargs/djangoparser.py
@@ -59,6 +59,9 @@ class DjangoParser(core.Parser):
         return req.COOKIES
 
     def load_headers(self, req, schema):
+        """Return headers from the request."""
+        # Django's HttpRequest.headers is a case-insensitive dict type, but it
+        # isn't a multidict, so this is not proxied
         return req.headers
 
     def load_files(self, req, schema):

--- a/src/webargs/djangoparser.py
+++ b/src/webargs/djangoparser.py
@@ -59,9 +59,7 @@ class DjangoParser(core.Parser):
         return req.COOKIES
 
     def load_headers(self, req, schema):
-        raise NotImplementedError(
-            f"Header parsing not supported by {self.__class__.__name__}"
-        )
+        return req.headers
 
     def load_files(self, req, schema):
         """Return files from the request as a MultiDictProxy."""

--- a/tests/test_djangoparser.py
+++ b/tests/test_djangoparser.py
@@ -14,10 +14,6 @@ class TestDjangoParser(CommonTestCase):
     def test_use_args_with_validation(self):
         pass
 
-    @pytest.mark.skip(reason="headers location not supported by DjangoParser")
-    def test_parsing_headers(self, testapp):
-        pass
-
     def test_parsing_in_class_based_view(self, testapp):
         assert testapp.get("/echo_cbv?name=Fred").json == {"name": "Fred"}
         assert testapp.post_json("/echo_cbv", {"name": "Fred"}).json == {"name": "Fred"}


### PR DESCRIPTION
Given the choice, use `HttpRequest.headers` rather than `HttpRequest.META`. `headers` was added in Django 2.2 to replace `META`, so it's what modern users should expect in terms of behavior.

The request headers are a case-insensitive mapping in Django, and this should work just fine with schema loading. There's no need to proxy the object since headers can't contain list-like data.

closes #540