### PR TITLE
Test against minimum supported framework versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,6 @@ jobs:
       - py37
       - py38
       - py39
-      - py39-mindeps
       - py39-marshmallowdev
       - docs
     os: linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,9 +27,11 @@ jobs:
     toxenvs:
       - lint
       - py36
+      - py36-mindeps
       - py37
       - py38
       - py39
+      - py39-mindeps
       - py39-marshmallowdev
       - docs
     os: linux

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ import re
 from setuptools import setup, find_packages
 
 FRAMEWORKS = [
-    "Flask>=0.12.2",
+    "Flask>=0.12.5",
     "Django>=2.2.0",
     "bottle>=0.12.13",
     "tornado>=4.5.2",
     "pyramid>=1.9.1",
     "webapp2>=3.0.0b1",
     "falcon>=2.0.0",
-    "aiohttp>=3.0.0",
+    "aiohttp>=3.0.8",
 ]
 EXTRAS_REQUIRE = {
     "frameworks": FRAMEWORKS,

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     lint
     py{36,37,38,39}
-    py{36,39}-mindeps
+    py36-mindeps
     py39-marshmallowdev
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
     lint
     py{36,37,38,39}
+    py{36,39}-mindeps
     py39-marshmallowdev
     docs
 
@@ -10,6 +11,13 @@ extras = tests
 deps =
     !marshmallowdev: marshmallow>=3.0.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
+    mindeps: Flask==0.12.5
+    mindeps: Django==2.2.0
+    mindeps: bottle==0.12.13
+    mindeps: tornado==4.5.2
+    mindeps: pyramid==1.9.1
+    mindeps: falcon==2.0.0
+    mindeps: aiohttp==3.0.8
 commands = pytest {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
This adds a tox factor, `mindeps`, which specifies explicitly that we want to test with old versions of the various frameworks.
Right now, it is only specified for our minimum and maximum supported python versions -- meaning 3.6 and 3.9 -- to keep the build matrix a little bit smaller.
These are also added in the azure pipelines config.

This testing is meant to "catch us" if we add a chunk of code to one of the parsers which will break on older framework versions. For example, we might use a request attribute without realizing that it was added in a minor version of a framework. We'd then  break compatibility with older (possibly still supported) framework versions.

This explicitly does not add any public documentation about minimum compatible versions. We don't offer a new guarantee to users and the support we offer is still loose and "best effort". But it does update the versions listed in `setup.py`, so if people are looking there to get a feel for what we support, they'll see something reasonable.

flask and aiohttp both failed on these builds. flask because it didn't start pinning the version of werkzeug until 0.12.5, and aiohttp because versions prior to 3.0.8 aren't py3.9-compatible. So these have been updated.

---

`webapp2` isn't actually supported and I think it should be removed from the list in `setup.py`, but I refrained from doing that for now.

I considered only testing on the oldest supported python (3.6), and I wouldn't mind doing it that way.
I also considered maybe adding a chunk of doc about supported/compatible versions, but nobody is asking us for a written policy. So I don't see a need for one at present.