### PR TITLE
Update changelog for v7.0.0b2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,9 +8,9 @@ Features:
 
 * `DjangoParser` now supports the `headers` location. (:issue:`540`)
 
-* `FalconParser` now defaults to the new `media` location, which uses
+* `FalconParser` now supports a new `media` location, which uses
   Falcon's `media` decoding. (:issue:`253`)
-  
+
 `media` behaves very similarly to the `json` location but also supports any
 registered media handler. See the
 `Falcon documentation on media types
@@ -18,8 +18,7 @@ registered media handler. See the
 
 Changes:
 
-* `FalconParser` now defaults to using the new `media` location instead of
-  `json`. (:issue:`253`)
+* `FalconParser` defaults to the `media` location instead of `json`. (:issue:`253`)
 
 * Test against Python 3.9.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,29 @@
 Changelog
 ---------
 
-(unreleased)
-************
+7.0.0b2 (unreleased)
+********************
 
-Other changes:
+Features:
+
+* `DjangoParser` now supports the `headers` location. (:issue:`540`)
+
+* `FalconParser` now defaults to the new `media` location, which uses
+  Falcon's `media` decoding. (:issue:`253`)
+  
+`media` behaves very similarly to the `json` location but also supports any
+registered media handler. See the
+`Falcon documentation on media types
+<https://falcon.readthedocs.io/en/stable/api/media.html>`_ for more details.
+
+Changes:
+
+* `FalconParser` now defaults to using the new `media` location instead of
+  `json`. (:issue:`253`)
 
 * Test against Python 3.9.
+
+* *Backwards-incompatible*: Drop support for Python 3.5.
 
 7.0.0b1 (2020-09-11)
 ********************


### PR DESCRIPTION
I was thinking that I would like to release v7.0.0b2 soon and I noticed that I haven't been putting in changelog entries the way I should.

This just gets the changelog up to date, and I'm happy to release 7.0.0b2 whenever this merges if that sounds good.