### PR TITLE
Add type annotations to Parser and fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Changes:
 
 * *Backwards-incompatible*: Drop support for webapp2 (:pr:`565`).
 
+* Add type annotations to `Parser` class, `DelimitedList`, and
+  `DelimitedTuple`. (:issue:`566`)
+
 7.0.0b2 (2020-12-01)
 ********************
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     url="https://github.com/marshmallow-code/webargs",
     packages=find_packages("src"),
     package_dir={"": "src"},
+    package_data={"webargs": ["py.typed"]},
     install_requires=["marshmallow>=3.0.0"],
     extras_require=EXTRAS_REQUIRE,
     license="MIT",

--- a/src/webargs/aiohttpparser.py
+++ b/src/webargs/aiohttpparser.py
@@ -155,8 +155,8 @@ class AIOHTTPParser(AsyncParser):
         req: Request,
         schema: Schema,
         *,
-        error_status_code: typing.Union[int, None],
-        error_headers: typing.Union[typing.Mapping[str, str], None]
+        error_status_code: typing.Optional[int],
+        error_headers: typing.Optional[typing.Mapping[str, str]]
     ) -> typing.NoReturn:
         """Handle ValidationErrors and return a JSON response of error messages
         to the client.

--- a/src/webargs/fields.py
+++ b/src/webargs/fields.py
@@ -13,6 +13,8 @@ tells webargs where to parse the request argument from.
         "content_type": fields.Str(data_key="Content-Type", location="headers"),
     }
 """
+import typing
+
 import marshmallow as ma
 
 # Expose all fields from marshmallow.fields.
@@ -52,7 +54,7 @@ class DelimitedFieldMixin:
     >>>     pass
     """
 
-    delimiter = ","
+    delimiter: str = ","
 
     def _serialize(self, value, attr, obj):
         # serializing will start with parent-class serialization, so that we correctly
@@ -80,9 +82,14 @@ class DelimitedList(DelimitedFieldMixin, ma.fields.List):
     """
 
     default_error_messages = {"invalid": "Not a valid delimited list."}
-    delimiter = ","
 
-    def __init__(self, cls_or_instance, *, delimiter=None, **kwargs):
+    def __init__(
+        self,
+        cls_or_instance: typing.Union[ma.fields.Field, type],
+        *,
+        delimiter: typing.Optional[str] = None,
+        **kwargs
+    ):
         self.delimiter = delimiter or self.delimiter
         super().__init__(cls_or_instance, **kwargs)
 
@@ -99,8 +106,9 @@ class DelimitedTuple(DelimitedFieldMixin, ma.fields.Tuple):
     """
 
     default_error_messages = {"invalid": "Not a valid delimited tuple."}
-    delimiter = ","
 
-    def __init__(self, tuple_fields, *, delimiter=None, **kwargs):
+    def __init__(
+        self, tuple_fields, *, delimiter: typing.Optional[str] = None, **kwargs
+    ):
         self.delimiter = delimiter or self.delimiter
         super().__init__(tuple_fields, **kwargs)

--- a/src/webargs/multidictproxy.py
+++ b/src/webargs/multidictproxy.py
@@ -1,5 +1,7 @@
 from collections.abc import Mapping
 
+import marshmallow as ma
+
 from webargs.core import missing, is_multiple
 
 
@@ -13,12 +15,12 @@ class MultiDictProxy(Mapping):
     In all other cases, __getitem__ proxies directly to the input multidict.
     """
 
-    def __init__(self, multidict, schema):
+    def __init__(self, multidict, schema: ma.Schema):
         self.data = multidict
         self.multiple_keys = self._collect_multiple_keys(schema)
 
     @staticmethod
-    def _collect_multiple_keys(schema):
+    def _collect_multiple_keys(schema: ma.Schema):
         result = set()
         for name, field in schema.fields.items():
             if not is_multiple(field):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1081,7 +1081,6 @@ def test_is_json():
 def test_get_mimetype():
     assert get_mimetype("application/json") == "application/json"
     assert get_mimetype("application/json;charset=utf8") == "application/json"
-    assert get_mimetype(None) is None
 
 
 class MockRequestParserWithErrorHandler(MockRequestParser):


### PR DESCRIPTION
The type annotations on the parser base class are mostly ported over from AsyncParser with some workarounds and other trickery (documented in comments and commit messages) based on two `mypy` issues I ran into and one bit of `async` vs non-`async` conflict.

The conflicts between `Parser` and `AsyncParser` make me want to try more radical refactoring at some point. The fact that we have async methods whose names match their synchronous counterparts is problematic. Maybe some shared base class for both of them could get us out of their direct inheritance relationship? It needs more thought but not for inclusion here.

---

I think this is good to go and is ready for review, but I want to actually try running `mypy` against some projects which use `webargs` to see if I can find issues that way. So if it's approved, I might hesitate to merge until I can do that.