### PR TITLE
Add section to upgrading doc for 7.0

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -127,6 +127,7 @@ When you need more flexibility in defining input schemas, you can pass a marshma
         username = args["username"]
         # ...
 
+.. _advanced_setting_unknown:
 
 Setting `unknown`
 -----------------

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -3,6 +3,54 @@ Upgrading to Newer Releases
 
 This section documents migration paths to new releases.
 
+Upgrading to 7.0
+++++++++++++++++
+
+`unknown` is Now Settable by the Parser
+---------------------------------------
+
+As of 7.0, `Parsers` have multiple settings for controlling the value for
+`unknown` which is passed to `schema.load` when parsing.
+
+To set unknown behavior on a parser, see the advanced doc on this topic:
+:ref:`advanced_setting_unknown`.
+
+Importantly, by default, any schema setting for `unknown` will be overridden by
+the `unknown` settings for the parser.
+
+In order to use a schema's `unknown` value, set `unknown=None` on the parser.
+In 6.x versions of webargs, schema values for `unknown` are used, so the
+`unknown=None` setting is the best way to emulate this.
+
+To get identical behavior:
+
+.. code-block:: python
+
+    # assuming you have a schema named MySchema
+
+    # webargs 6.x
+    @parser.use_args(MySchema)
+    def foo(args):
+        ...
+
+
+    # webargs 7.x
+    # as a parameter to use_args or parse
+    @parser.use_args(MySchema, unknown=None)
+    def foo(args):
+        ...
+
+
+    # webargs 7.x
+    # as a parser setting
+    # example with flaskparser, but any parser class works
+    parser = FlaskParser(unknown=None)
+
+
+    @parser.use_args(MySchema)
+    def foo(args):
+        ...
+
 Upgrading to 6.0
 ++++++++++++++++
 


### PR DESCRIPTION
After 7.0, I looked over things to see if there are/were doc improvements we need to make. This was the one thing that jumped out -- the upgrading doc should have a new section.

Focus on explaining the changes to `unknown` and clarifying for anyone on 6.x that to use their schema's settings, they should set `unknown=None`.