### PR TITLE
Fix issues with type annotations and pass through kwargs to _serialize in delimited fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+7.0.1 (Unreleased)
+******************
+
+Bug fixes:
+
+* Fix `DelimitedList` and `DelimitedTuple` to pass additional keyword arguments
+  through their `_serialize` methods to the child fields and fix type checking
+  on these classes. (:issue:`569`)
+  Thanks to :user:`decaz` for reporting.
+
 7.0.0 (2020-12-10)
 ******************
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
   parameters:
     toxenvs:
       - lint
+      - mypy
       - py36
       - py36-mindeps
       - py37

--- a/src/webargs/aiohttpparser.py
+++ b/src/webargs/aiohttpparser.py
@@ -25,7 +25,6 @@ Example: ::
 import typing
 
 from aiohttp import web
-from aiohttp.web import Request
 from aiohttp import web_exceptions
 from marshmallow import Schema, ValidationError, RAISE
 
@@ -35,7 +34,7 @@ from webargs.asyncparser import AsyncParser
 from webargs.multidictproxy import MultiDictProxy
 
 
-def is_json_request(req: Request) -> bool:
+def is_json_request(req) -> bool:
     content_type = req.content_type
     return core.is_json(content_type)
 
@@ -83,24 +82,24 @@ class AIOHTTPParser(AsyncParser):
         **core.Parser.__location_map__,
     )
 
-    def load_querystring(self, req: Request, schema: Schema) -> MultiDictProxy:
+    def load_querystring(self, req, schema: Schema) -> MultiDictProxy:
         """Return query params from the request as a MultiDictProxy."""
         return MultiDictProxy(req.query, schema)
 
-    async def load_form(self, req: Request, schema: Schema) -> MultiDictProxy:
+    async def load_form(self, req, schema: Schema) -> MultiDictProxy:
         """Return form values from the request as a MultiDictProxy."""
         post_data = await req.post()
         return MultiDictProxy(post_data, schema)
 
     async def load_json_or_form(
-        self, req: Request, schema: Schema
+        self, req, schema: Schema
     ) -> typing.Union[typing.Dict, MultiDictProxy]:
         data = await self.load_json(req, schema)
         if data is not core.missing:
             return data
         return await self.load_form(req, schema)
 
-    async def load_json(self, req: Request, schema: Schema) -> typing.Dict:
+    async def load_json(self, req, schema: Schema):
         """Return a parsed json payload from the request."""
         if not (req.body_exists and is_json_request(req)):
             return core.missing
@@ -113,27 +112,27 @@ class AIOHTTPParser(AsyncParser):
         except UnicodeDecodeError as exc:
             return self._handle_invalid_json_error(exc, req)
 
-    def load_headers(self, req: Request, schema: Schema) -> MultiDictProxy:
+    def load_headers(self, req, schema: Schema) -> MultiDictProxy:
         """Return headers from the request as a MultiDictProxy."""
         return MultiDictProxy(req.headers, schema)
 
-    def load_cookies(self, req: Request, schema: Schema) -> MultiDictProxy:
+    def load_cookies(self, req, schema: Schema) -> MultiDictProxy:
         """Return cookies from the request as a MultiDictProxy."""
         return MultiDictProxy(req.cookies, schema)
 
-    def load_files(self, req: Request, schema: Schema) -> typing.NoReturn:
+    def load_files(self, req, schema: Schema) -> typing.NoReturn:
         raise NotImplementedError(
             "load_files is not implemented. You may be able to use load_form for "
             "parsing upload data."
         )
 
-    def load_match_info(self, req: Request, schema: Schema) -> typing.Mapping:
+    def load_match_info(self, req, schema: Schema) -> typing.Mapping:
         """Load the request's ``match_info``."""
         return req.match_info
 
     def get_request_from_view_args(
         self, view: typing.Callable, args: typing.Iterable, kwargs: typing.Mapping
-    ) -> Request:
+    ):
         """Get request object from a handler function or method. Used internally by
         ``use_args`` and ``use_kwargs``.
         """
@@ -152,7 +151,7 @@ class AIOHTTPParser(AsyncParser):
     def handle_error(
         self,
         error: ValidationError,
-        req: Request,
+        req,
         schema: Schema,
         *,
         error_status_code: typing.Optional[int],
@@ -176,7 +175,7 @@ class AIOHTTPParser(AsyncParser):
     def _handle_invalid_json_error(
         self,
         error: typing.Union[json.JSONDecodeError, UnicodeDecodeError],
-        req: Request,
+        req,
         *args,
         **kwargs
     ) -> typing.NoReturn:

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -45,7 +45,9 @@ class AsyncParser(core.Parser):
                 else self.DEFAULT_UNKNOWN_BY_LOCATION.get(location)
             )
         )
-        load_kwargs = {"unknown": unknown}
+        load_kwargs: typing.Dict[str, typing.Any] = (
+            {"unknown": unknown} if unknown else {}
+        )
         if req is None:
             raise ValueError("Must pass req object")
         data = None

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -194,7 +194,7 @@ class Parser:
 
     def _load_location_data(
         self, *, schema: ma.Schema, req: Request, location: str
-    ) -> typing.Optional[typing.Mapping]:
+    ) -> typing.Mapping:
         """Return a dictionary-like object for the location on the given request.
 
         Needs to have the schema in hand in order to correctly handle loading
@@ -308,7 +308,9 @@ class Parser:
                 else self.DEFAULT_UNKNOWN_BY_LOCATION.get(location)
             )
         )
-        load_kwargs = {"unknown": unknown} if unknown else {}
+        load_kwargs: typing.Dict[str, typing.Any] = (
+            {"unknown": unknown} if unknown else {}
+        )
         if req is None:
             raise ValueError("Must pass req object")
         data = None

--- a/src/webargs/fields.py
+++ b/src/webargs/fields.py
@@ -23,7 +23,7 @@ from marshmallow.fields import *  # noqa: F40
 __all__ = ["DelimitedList"] + ma.fields.__all__
 
 
-class Nested(ma.fields.Nested):
+class Nested(ma.fields.Nested):  # type: ignore[no-redef]
     """Same as `marshmallow.fields.Nested`, except can be passed a dictionary as
     the first argument, which will be converted to a `marshmallow.Schema`.
 
@@ -56,11 +56,11 @@ class DelimitedFieldMixin:
 
     delimiter: str = ","
 
-    def _serialize(self, value, attr, obj):
+    def _serialize(self, value, attr, obj, **kwargs):
         # serializing will start with parent-class serialization, so that we correctly
         # output lists of non-primitive types, e.g. DelimitedList(DateTime)
         return self.delimiter.join(
-            format(each) for each in super()._serialize(value, attr, obj)
+            format(each) for each in super()._serialize(value, attr, obj, **kwargs)
         )
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,13 @@ deps = pre-commit~=2.4
 skip_install = true
 commands = pre-commit run --all-files
 
+# a separate `mypy` target which runs `mypy` in an environment with
+# `webargs` and `marshmallow` both installed is a valuable safeguard against
+# issues in which `mypy` running on every file standalone won't catch things
+[testenv:mypy]
+deps = mypy
+commands = mypy src/
+
 [testenv:docs]
 extras = docs
 commands = sphinx-build docs/ docs/_build {posargs}


### PR DESCRIPTION
This resolves #569 

In the particular case cited there, `DelimitedList._serialize` and `DelimitedTuple._serialize` weren't taking additional keyword arguments even though that's required to be compatible with the function signature in `Field._serialize`.
In addition to taking the args, use the same behavior as `marshmallow.fields.List` and pass the keyword args through to the inner field's `_serialize` method.

I also found several much more minor issues when trying to run `mypy` from an environment which had webargs installed, and I've resolved all of them (sometimes by removing annotations which we can come back to later).

To ensure that this kind of flaw can't creep back in, I've added `tox -e mypy` as a separate test env which runs mypy, and added config to run that test in azure pipelines.

I intend to release this right away as 7.0.1 since the type signature issue could be stopping people from upgrading.