### PR TITLE
Replace mypy tox target with fixed precommit conf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,4 @@ repos:
   - id: mypy
     language_version: python3
     files: ^src/webargs/
+    additional_dependencies: ["marshmallow>=3,<4"]

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ commands = pre-commit run --all-files
 # issues in which `mypy` running on every file standalone won't catch things
 [testenv:mypy]
 deps = mypy
+extras = frameworks
 commands = mypy src/
 
 [testenv:docs]


### PR DESCRIPTION
In 7.0.1 I introduced a new tox target because I wasn't sure about what had gone wrong with `mypy` and didn't want to take risks.
It turns out, that was overkill. After testing, I'm quite confident that the _only_ problem was that `marshmallow` was not installed into the `mypy` environment. Detail (per the commit message) below.

You can test this by checking out `7.0.0` and trying this config against it -- you'll get pre-commit errors from the few bad signatures which were present in that version.

cc @sloria Even though you haven't been involved, I thought I ought to give you a heads up in case this impacts other projects too.

---

The issues with undiscovered type errors actually derived from the fact that `marshmallow` was not available in the `mypy` environment.
As a result, values like `missing` could not be resolved and were typed as `Any`. That, in turn, leads to "strangely incorrect" signatures like `Union[Dict, Any]` (a.k.a. `Any`), which then can result in type errors that ought to be identified being missed.

Once `marshmallow` is installed, mypy will find types like `Union[Dict, _Missing]`, and can determine that they do (or do not) match as appropriate.