### PR TITLE
Add support for the `is_multiple` field attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+7.1.0 (Unreleased)
+******************
+
+Features:
+
+* Detection of fields as "multi-value" for unpacking lists from multi-dict
+  types is now extensible with the `is_multiple` attribute. If a field sets
+  `is_multiple = True` it will be detected as a multi-value field.
+  (:issue:`563`)
+
+* If `is_multiple` is not set or is set to `None`, webargs will check if the
+  field is an instance of `List`.
+
 7.0.1 (2020-12-14)
 ******************
 

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -35,8 +35,8 @@ T = typing.TypeVar("T")
 # a set of fields which are known to satisfy the `is_multiple` criteria, but
 # which come from marshmallow and therefore don't know about webargs (and
 # do not set `is_multiple=True`)
-# TODO: should `ma.fields.Tuple` be added here?
-KNOWN_MULTI_FIELDS: typing.Tuple[typing.Type, ...] = (ma.fields.List,)
+# TODO: `ma.fields.Tuple` should be added here in v8.0
+KNOWN_MULTI_FIELDS: typing.List[typing.Type] = [ma.fields.List]
 
 
 # a value used as the default for arguments, so that when `None` is passed, it
@@ -68,7 +68,7 @@ def is_multiple(field: ma.fields.Field) -> bool:
     is_multiple_attr = getattr(field, "is_multiple", None)
     if is_multiple_attr is not None:
         return is_multiple_attr
-    return isinstance(field, KNOWN_MULTI_FIELDS)
+    return isinstance(field, tuple(KNOWN_MULTI_FIELDS))
 
 
 def get_mimetype(content_type: str) -> str:

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -8,8 +8,6 @@ import marshmallow as ma
 from marshmallow import ValidationError
 from marshmallow.utils import missing
 
-from webargs.fields import DelimitedList
-
 logger = logging.getLogger(__name__)
 
 
@@ -33,6 +31,12 @@ CallableList = typing.List[typing.Callable]
 ErrorHandler = typing.Callable[..., typing.NoReturn]
 # generic type var with no particular meaning
 T = typing.TypeVar("T")
+
+# a set of fields which are known to satisfy the `is_multiple` criteria, but
+# which come from marshmallow and therefore don't know about webargs (and
+# do not set `is_multiple=True`)
+# TODO: should `ma.fields.Tuple` be added here?
+KNOWN_MULTI_FIELDS: typing.Tuple[typing.Type, ...] = (ma.fields.List,)
 
 
 # a value used as the default for arguments, so that when `None` is passed, it
@@ -59,7 +63,12 @@ def _callable_or_raise(obj: typing.Optional[T]) -> typing.Optional[T]:
 
 def is_multiple(field: ma.fields.Field) -> bool:
     """Return whether or not `field` handles repeated/multi-value arguments."""
-    return isinstance(field, ma.fields.List) and not isinstance(field, DelimitedList)
+    # fields which set `is_multiple = True/False` will have the value selected,
+    # otherwise, we check for explicit criteria
+    is_multiple_attr = getattr(field, "is_multiple", None)
+    if is_multiple_attr is not None:
+        return is_multiple_attr
+    return isinstance(field, KNOWN_MULTI_FIELDS)
 
 
 def get_mimetype(content_type: str) -> str:

--- a/src/webargs/fields.py
+++ b/src/webargs/fields.py
@@ -55,6 +55,8 @@ class DelimitedFieldMixin:
     """
 
     delimiter: str = ","
+    # delimited fields set is_multiple=False for webargs.core.is_multiple
+    is_multiple: bool = False
 
     def _serialize(self, value, attr, obj, **kwargs):
         # serializing will start with parent-class serialization, so that we correctly

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1032,6 +1032,72 @@ def test_type_conversion_with_multiple_required(web_request, parser):
         parser.parse(args, web_request)
 
 
+@pytest.mark.parametrize("input_dict", multidicts)
+@pytest.mark.parametrize(
+    "setting",
+    ["is_multiple_true", "is_multiple_false", "is_multiple_notset", "list_field"],
+)
+def test_is_multiple_detection(web_request, parser, input_dict, setting):
+    # define a custom List-like type which deserializes string lists
+    str_instance = fields.String()
+
+    # this custom class "multiplexes" in that it can be given a single value or
+    # list of values -- a single value is treated as a string, and a list of
+    # values is treated as a list of strings
+    class CustomMultiplexingField(fields.Field):
+        def _deserialize(self, value, attr, data, **kwargs):
+            if isinstance(value, str):
+                return str_instance.deserialize(value, **kwargs)
+            return [str_instance.deserialize(v, **kwargs) for v in value]
+
+        def _serialize(self, value, attr, data, **kwargs):
+            if isinstance(value, str):
+                return str_instance._serialize(value, **kwargs)
+            return [str_instance._serialize(v, **kwargs) for v in value]
+
+    class CustomMultipleField(CustomMultiplexingField):
+        is_multiple = True
+
+    class CustomNonMultipleField(CustomMultiplexingField):
+        is_multiple = False
+
+    # the request's query params are the input multidict
+    web_request.query = input_dict
+
+    # case 1: is_multiple=True
+    if setting == "is_multiple_true":
+        # the multidict should unpack to a list of strings
+        #
+        # order is not necessarily guaranteed by the multidict implementations, but
+        # both values must be present
+        args = {"foos": CustomMultipleField()}
+        result = parser.parse(args, web_request, location="query")
+        assert result["foos"] in (["a", "b"], ["b", "a"])
+    # case 2: is_multiple=False
+    elif setting == "is_multiple_false":
+        # the multidict should unpack to a string
+        #
+        # either value may be returned, depending on the multidict implementation,
+        # but not both
+        args = {"foos": CustomNonMultipleField()}
+        result = parser.parse(args, web_request, location="query")
+        assert result["foos"] in ("a", "b")
+    # case 3: is_multiple is not set
+    elif setting == "is_multiple_notset":
+        # this should be the same as is_multiple=False
+        args = {"foos": CustomMultiplexingField()}
+        result = parser.parse(args, web_request, location="query")
+        assert result["foos"] in ("a", "b")
+    # case 4: the field is a List (special case)
+    elif setting == "list_field":
+        # this should behave like the is_multiple=True case
+        args = {"foos": fields.List(fields.Str())}
+        result = parser.parse(args, web_request, location="query")
+        assert result["foos"] in (["a", "b"], ["b", "a"])
+    else:
+        raise NotImplementedError
+
+
 def test_validation_errors_in_validator_are_passed_to_handle_error(parser, web_request):
     def validate(value):
         raise ValidationError("Something went wrong.")


### PR DESCRIPTION
This resolves #563

Detection of fields as `is_multiple` for multi-dict unpacking now allows custom fields to use an attribute `is_multiple=T/F` to control the behavior directly. This allows for a subclass of `List` to set `is_multiple=False` (done by `DelimitedList`) and allows non-`List` subclasses to be detected as `multiple`.

Because `is_multiple` is an attribute, it can be set on the field class or on an instance.

A noted TODO comment questions whether or not `ma.fields.Tuple` should be added to the auto-detected fields for `is_multiple`. I wasn't certain if we should add it or not, but I think so? I'll open a follow-up issue to decide on it for 8.0 -- I don't think we should do it in 7.x since 8.0 is on the horizon.

Tests cover
- a field with is_multiple=True
- a field with is_multiple=False
- a field where is_multiple is not set
- a List(Str()) field

and run against the collection of multidict implementations used to test MultiDictProxy.