### PR TITLE
Make KNOWN_MULTI_FIELDS configurable and add doc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Features:
 * If `is_multiple` is not set or is set to `None`, webargs will check if the
   field is an instance of `List`.
 
+* A new attribute on `Parser` objects, ``Parser.KNOWN_MULTI_FIELDS`` can be
+  used to set fields which should be detected as ``is_multiple=True`` even when
+  the attribute is not set.
+
+See docs on "Multi-Field Detection" for more details.
+
 7.0.1 (2020-12-14)
 ******************
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -503,7 +503,7 @@ if present.
 
 To implement this behavior, webargs will examine schemas for ``marshmallow.fields.List``
 fields. ``List`` fields get unpacked to list values when data is loaded, and
-other fields do not. This also applies fields which inherit from ``List``.
+other fields do not. This also applies to fields which inherit from ``List``.
 
 .. note::
 
@@ -520,19 +520,20 @@ strings to serve as an example:
 .. code-block:: python
 
     # a custom field class which can accept values like List(String()) or String()
-    str_instance = fields.String()
-
-
-    class CustomMultiplexingField(fields.Field):
+    class CustomMultiplexingField(fields.String):
         def _deserialize(self, value, attr, data, **kwargs):
             if isinstance(value, str):
-                return str_instance.deserialize(value, **kwargs)
-            return [str_instance.deserialize(v, **kwargs) for v in value]
+                return super()._deserialize(value, attr, data, **kwargs)
+            return [
+                self._deserialize(v, attr, data, **kwargs)
+                for v in value
+                if isinstance(v, str)
+            ]
 
-        def _serialize(self, value, attr, data, **kwargs):
+        def _serialize(self, value, attr, **kwargs):
             if isinstance(value, str):
-                return str_instance._serialize(value, **kwargs)
-            return [str_instance._serialize(v, **kwargs) for v in value]
+                return super()._serialize(value, attr, **kwargs)
+            return [self._serialize(v, attr, **kwargs) for v in value if isinstance(v, str)]
 
 
 If you control the definition of ``CustomMultiplexingField``, you can just add

--- a/src/webargs/aiohttpparser.py
+++ b/src/webargs/aiohttpparser.py
@@ -84,12 +84,12 @@ class AIOHTTPParser(AsyncParser):
 
     def load_querystring(self, req, schema: Schema) -> MultiDictProxy:
         """Return query params from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.query, schema)
+        return self._makeproxy(req.query, schema)
 
     async def load_form(self, req, schema: Schema) -> MultiDictProxy:
         """Return form values from the request as a MultiDictProxy."""
         post_data = await req.post()
-        return MultiDictProxy(post_data, schema)
+        return self._makeproxy(post_data, schema)
 
     async def load_json_or_form(
         self, req, schema: Schema
@@ -114,11 +114,11 @@ class AIOHTTPParser(AsyncParser):
 
     def load_headers(self, req, schema: Schema) -> MultiDictProxy:
         """Return headers from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.headers, schema)
+        return self._makeproxy(req.headers, schema)
 
     def load_cookies(self, req, schema: Schema) -> MultiDictProxy:
         """Return cookies from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.cookies, schema)
+        return self._makeproxy(req.cookies, schema)
 
     def load_files(self, req, schema: Schema) -> typing.NoReturn:
         raise NotImplementedError(

--- a/src/webargs/bottleparser.py
+++ b/src/webargs/bottleparser.py
@@ -19,7 +19,6 @@ Example: ::
 import bottle
 
 from webargs import core
-from webargs.multidictproxy import MultiDictProxy
 
 
 class BottleParser(core.Parser):
@@ -49,7 +48,7 @@ class BottleParser(core.Parser):
 
     def load_querystring(self, req, schema):
         """Return query params from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.query, schema)
+        return self._makeproxy(req.query, schema)
 
     def load_form(self, req, schema):
         """Return form values from the request as a MultiDictProxy."""
@@ -58,11 +57,11 @@ class BottleParser(core.Parser):
         #  TODO: Make this check more specific
         if core.is_json(req.content_type):
             return core.missing
-        return MultiDictProxy(req.forms, schema)
+        return self._makeproxy(req.forms, schema)
 
     def load_headers(self, req, schema):
         """Return headers from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.headers, schema)
+        return self._makeproxy(req.headers, schema)
 
     def load_cookies(self, req, schema):
         """Return cookies from the request."""
@@ -70,7 +69,7 @@ class BottleParser(core.Parser):
 
     def load_files(self, req, schema):
         """Return files from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.files, schema)
+        return self._makeproxy(req.files, schema)
 
     def handle_error(self, error, req, schema, *, error_status_code, error_headers):
         """Handles errors during parsing. Aborts the current request with a

--- a/src/webargs/djangoparser.py
+++ b/src/webargs/djangoparser.py
@@ -18,7 +18,6 @@ Example usage: ::
             return HttpResponse('Hello ' + args['name'])
 """
 from webargs import core
-from webargs.multidictproxy import MultiDictProxy
 
 
 def is_json_request(req):
@@ -48,11 +47,11 @@ class DjangoParser(core.Parser):
 
     def load_querystring(self, req, schema):
         """Return query params from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.GET, schema)
+        return self._makeproxy(req.GET, schema)
 
     def load_form(self, req, schema):
         """Return form values from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.POST, schema)
+        return self._makeproxy(req.POST, schema)
 
     def load_cookies(self, req, schema):
         """Return cookies from the request."""
@@ -66,7 +65,7 @@ class DjangoParser(core.Parser):
 
     def load_files(self, req, schema):
         """Return files from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.FILES, schema)
+        return self._makeproxy(req.FILES, schema)
 
     def get_request_from_view_args(self, view, args, kwargs):
         # The first argument is either `self` or `request`

--- a/src/webargs/falconparser.py
+++ b/src/webargs/falconparser.py
@@ -6,7 +6,6 @@ from falcon.util.uri import parse_query_string
 import marshmallow as ma
 
 from webargs import core
-from webargs.multidictproxy import MultiDictProxy
 
 HTTP_422 = "422 Unprocessable Entity"
 
@@ -97,7 +96,7 @@ class FalconParser(core.Parser):
 
     def load_querystring(self, req, schema):
         """Return query params from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.params, schema)
+        return self._makeproxy(req.params, schema)
 
     def load_form(self, req, schema):
         """Return form values from the request as a MultiDictProxy
@@ -109,7 +108,7 @@ class FalconParser(core.Parser):
         form = parse_form_body(req)
         if form is core.missing:
             return form
-        return MultiDictProxy(form, schema)
+        return self._makeproxy(form, schema)
 
     def load_media(self, req, schema):
         """Return data unpacked and parsed by one of Falcon's media handlers.

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -26,7 +26,6 @@ from werkzeug.exceptions import HTTPException
 import marshmallow as ma
 
 from webargs import core
-from webargs.multidictproxy import MultiDictProxy
 
 
 def abort(http_status_code, exc=None, **kwargs):
@@ -80,15 +79,15 @@ class FlaskParser(core.Parser):
 
     def load_querystring(self, req, schema):
         """Return query params from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.args, schema)
+        return self._makeproxy(req.args, schema)
 
     def load_form(self, req, schema):
         """Return form values from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.form, schema)
+        return self._makeproxy(req.form, schema)
 
     def load_headers(self, req, schema):
         """Return headers from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.headers, schema)
+        return self._makeproxy(req.headers, schema)
 
     def load_cookies(self, req, schema):
         """Return cookies from the request."""
@@ -96,7 +95,7 @@ class FlaskParser(core.Parser):
 
     def load_files(self, req, schema):
         """Return files from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.files, schema)
+        return self._makeproxy(req.files, schema)
 
     def handle_error(self, error, req, schema, *, error_status_code, error_headers):
         """Handles errors during parsing. Aborts the current HTTP request and

--- a/src/webargs/pyramidparser.py
+++ b/src/webargs/pyramidparser.py
@@ -34,7 +34,6 @@ import marshmallow as ma
 
 from webargs import core
 from webargs.core import json
-from webargs.multidictproxy import MultiDictProxy
 
 
 def is_json_request(req):
@@ -67,28 +66,28 @@ class PyramidParser(core.Parser):
 
     def load_querystring(self, req, schema):
         """Return query params from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.GET, schema)
+        return self._makeproxy(req.GET, schema)
 
     def load_form(self, req, schema):
         """Return form values from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.POST, schema)
+        return self._makeproxy(req.POST, schema)
 
     def load_cookies(self, req, schema):
         """Return cookies from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.cookies, schema)
+        return self._makeproxy(req.cookies, schema)
 
     def load_headers(self, req, schema):
         """Return headers from the request as a MultiDictProxy."""
-        return MultiDictProxy(req.headers, schema)
+        return self._makeproxy(req.headers, schema)
 
     def load_files(self, req, schema):
         """Return files from the request as a MultiDictProxy."""
         files = ((k, v) for k, v in req.POST.items() if hasattr(v, "file"))
-        return MultiDictProxy(MultiDict(files), schema)
+        return self._makeproxy(MultiDict(files), schema)
 
     def load_matchdict(self, req, schema):
         """Return the request's ``matchdict`` as a MultiDictProxy."""
-        return MultiDictProxy(req.matchdict, schema)
+        return self._makeproxy(req.matchdict, schema)
 
     def handle_error(self, error, req, schema, *, error_status_code, error_headers):
         """Handles errors during parsing. Aborts the current HTTP request and

--- a/src/webargs/tornadoparser.py
+++ b/src/webargs/tornadoparser.py
@@ -97,25 +97,31 @@ class TornadoParser(core.Parser):
 
     def load_querystring(self, req, schema):
         """Return query params from the request as a MultiDictProxy."""
-        return WebArgsTornadoMultiDictProxy(req.query_arguments, schema)
+        return self._makeproxy(
+            req.query_arguments, schema, cls=WebArgsTornadoMultiDictProxy
+        )
 
     def load_form(self, req, schema):
         """Return form values from the request as a MultiDictProxy."""
-        return WebArgsTornadoMultiDictProxy(req.body_arguments, schema)
+        return self._makeproxy(
+            req.body_arguments, schema, cls=WebArgsTornadoMultiDictProxy
+        )
 
     def load_headers(self, req, schema):
         """Return headers from the request as a MultiDictProxy."""
-        return WebArgsTornadoMultiDictProxy(req.headers, schema)
+        return self._makeproxy(req.headers, schema, cls=WebArgsTornadoMultiDictProxy)
 
     def load_cookies(self, req, schema):
         """Return cookies from the request as a MultiDictProxy."""
         # use the specialized subclass specifically for handling Tornado
         # cookies
-        return WebArgsTornadoCookiesMultiDictProxy(req.cookies, schema)
+        return self._makeproxy(
+            req.cookies, schema, cls=WebArgsTornadoCookiesMultiDictProxy
+        )
 
     def load_files(self, req, schema):
         """Return files from the request as a MultiDictProxy."""
-        return WebArgsTornadoMultiDictProxy(req.files, schema)
+        return self._makeproxy(req.files, schema, cls=WebArgsTornadoMultiDictProxy)
 
     def handle_error(self, error, req, schema, *, error_status_code, error_headers):
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1035,7 +1035,13 @@ def test_type_conversion_with_multiple_required(web_request, parser):
 @pytest.mark.parametrize("input_dict", multidicts)
 @pytest.mark.parametrize(
     "setting",
-    ["is_multiple_true", "is_multiple_false", "is_multiple_notset", "list_field"],
+    [
+        "is_multiple_true",
+        "is_multiple_false",
+        "is_multiple_notset",
+        "list_field",
+        "added_to_known",
+    ],
 )
 def test_is_multiple_detection(web_request, parser, input_dict, setting):
     # define a custom List-like type which deserializes string lists
@@ -1094,6 +1100,13 @@ def test_is_multiple_detection(web_request, parser, input_dict, setting):
         args = {"foos": fields.List(fields.Str())}
         result = parser.parse(args, web_request, location="query")
         assert result["foos"] in (["a", "b"], ["b", "a"])
+    elif setting == "added_to_known":
+        # if it's included in the known multifields and is_multiple is not set, behave
+        # like is_multiple=True
+        parser.KNOWN_MULTI_FIELDS.append(CustomMultiplexingField)
+        args = {"foos": CustomMultiplexingField()}
+        result = parser.parse(args, web_request, location="query")
+        assert result["foos"] in ("a", "b")
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Rather than a module-level constant, move ``KNOWN_MULTI_FIELDS`` to be a parser attribute. This will allow users to override or modify it. However, moving it creates a problem: whereas previously `is_multiple` was just a function which MultiDictProxy could safely call, now it's a method and requires a Parser instance.
(NB: `is_multiple` actually moved from Parser to MultiDictProxy, but my first draft put it on the parser.)

To handle this, change the relationship between the multidictproxy and core modules. `core` now requires `multidictproxy` and the base `Parser` provides a private method for building a MultiDictProxy object.

MultiDictProxy doesn't depend on parsers (tried that, didn't like it). Instead, a MultiDictProxy can be given a `known_multi_fields` argument when created. The `_makeproxy` helper on the Parser class just makes sure to pass `known_multi_fields=self.KNOWN_MULTI_FIELDS`, and everything falls into place from there. Numerous tweaks to parser classes use `_makeproxy` instead of directly instantiating a MultiDictProxy, but that's the bulk of the changeset.

New docs in a section towards the end of the advanced doc explains how multi field detection works and explains how you can set `is_multiple = True` or add a field class to `Parser.KNOWN_MULTI_FIELDS`.

---

If we like this, I think I'll release v7.1 when it merges. If we don't, let's figure out what kind of doc & interface we want instead.