### PR TITLE
fix: distutils LooseVersion deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     package_data={"webargs": ["py.typed"]},
-    install_requires=["marshmallow>=3.0.0"],
+    install_requires=["marshmallow>=3.0.0", "packaging"],
     extras_require=EXTRAS_REQUIRE,
     license="MIT",
     zip_safe=False,

--- a/src/webargs/__init__.py
+++ b/src/webargs/__init__.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 from marshmallow.utils import missing
 
 # Make marshmallow's validation functions importable from webargs
@@ -8,5 +8,8 @@ from webargs.core import ValidationError
 from webargs import fields
 
 __version__ = "8.0.1"
-__version_info__ = tuple(LooseVersion(__version__).version)
+__parsed_version__ = Version(__version__)
+__version_info__ = __parsed_version__.release
+if __parsed_version__.pre:
+    __version_info__ += __parsed_version__.pre
 __all__ = ("ValidationError", "fields", "missing", "validate")


### PR DESCRIPTION
This mirrors https://github.com/marshmallow-code/marshmallow/pull/1903 by fixing the distutils deprecation warning by using packaging.version instead.

