### PR TITLE
Pin mypy version in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands = pre-commit run --all-files
 # `webargs` and `marshmallow` both installed is a valuable safeguard against
 # issues in which `mypy` running on every file standalone won't catch things
 [testenv:mypy]
-deps = mypy
+deps = mypy==0.910
 extras = frameworks
 commands = mypy src/
 


### PR DESCRIPTION
Currently pinning to 0.910 due to #667.