### PR TITLE
Fix type annotations for `__version_info__` + update mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     additional_dependencies: [black==21.12b0]
     args: ["--target-version", "py37"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910-1
+  rev: v0.930
   hooks:
   - id: mypy
     language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
   - id: mypy
     language_version: python3
     files: ^src/webargs/
-    additional_dependencies: ["marshmallow>=3,<4"]
+    additional_dependencies: ["marshmallow>=3,<4", "packaging"]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ EXTRAS_REQUIRE = {
     ]
     + FRAMEWORKS,
     "lint": [
-        "mypy==0.910",
+        "mypy==0.930",
         "flake8==4.0.1",
         "flake8-bugbear==21.11.29",
         "pre-commit~=2.4",

--- a/src/webargs/__init__.py
+++ b/src/webargs/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from packaging.version import Version
 from marshmallow.utils import missing
 
@@ -9,7 +11,9 @@ from webargs import fields
 
 __version__ = "8.0.1"
 __parsed_version__ = Version(__version__)
-__version_info__ = __parsed_version__.release
+__version_info__: tuple[int, int, int] | tuple[
+    int, int, int, str, int
+] = __parsed_version__.release  # type: ignore[assignment]
 if __parsed_version__.pre:
-    __version_info__ += __parsed_version__.pre
+    __version_info__ += __parsed_version__.pre  # type: ignore[assignment]
 __all__ = ("ValidationError", "fields", "missing", "validate")

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands = pre-commit run --all-files
 # `webargs` and `marshmallow` both installed is a valuable safeguard against
 # issues in which `mypy` running on every file standalone won't catch things
 [testenv:mypy]
-deps = mypy==0.910
+deps = mypy==0.930
 extras = frameworks
 commands = mypy src/
 


### PR DESCRIPTION
Mirrors the work in https://github.com/marshmallow-code/marshmallow/pull/1925

Resolves #667, #670

With this fixed, the latest mypy is usable again, so I've included the update.