### PR TITLE
Rename `Nested` to `WebargsNested`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,7 +14,7 @@ webargs.fields
 --------------
 
 .. automodule:: webargs.fields
-    :members: Nested, DelimitedList
+    :members: WebargsNested, DelimitedList, DelimitedTuple
 
 
 webargs.multidictproxy

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -228,7 +228,7 @@ Nesting Fields
     from webargs import fields
 
     args = {
-        "name": fields.Nested(
+        "name": fields.WebargsNested(
             {"first": fields.Str(required=True), "last": fields.Str(required=True)}
         )
     }

--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -134,7 +134,7 @@ async def echo_cookie(request):
 
 
 async def echo_nested(request):
-    args = {"name": fields.Nested({"first": fields.Str(), "last": fields.Str()})}
+    args = {"name": fields.WebargsNested({"first": fields.Str(), "last": fields.Str()})}
     parsed = await parser.parse(args, request)
     return json_response(parsed)
 
@@ -147,7 +147,9 @@ async def echo_multiple_args(request):
 
 async def echo_nested_many(request):
     args = {
-        "users": fields.Nested({"id": fields.Int(), "name": fields.Str()}, many=True)
+        "users": fields.WebargsNested(
+            {"id": fields.Int(), "name": fields.Str()}, many=True
+        )
     }
     parsed = await parser.parse(args, request)
     return json_response(parsed)
@@ -155,7 +157,9 @@ async def echo_nested_many(request):
 
 async def echo_nested_many_data_key(request):
     args = {
-        "x_field": fields.Nested({"id": fields.Int()}, many=True, data_key="X-Field")
+        "x_field": fields.WebargsNested(
+            {"id": fields.Int()}, many=True, data_key="X-Field"
+        )
     }
     parsed = await parser.parse(args, request)
     return json_response(parsed)

--- a/tests/apps/bottle_app.py
+++ b/tests/apps/bottle_app.py
@@ -142,14 +142,16 @@ def echo_file():
 
 @app.route("/echo_nested", method=["POST"])
 def echo_nested():
-    args = {"name": fields.Nested({"first": fields.Str(), "last": fields.Str()})}
+    args = {"name": fields.WebargsNested({"first": fields.Str(), "last": fields.Str()})}
     return parser.parse(args)
 
 
 @app.route("/echo_nested_many", method=["POST"])
 def echo_nested_many():
     args = {
-        "users": fields.Nested({"id": fields.Int(), "name": fields.Str()}, many=True)
+        "users": fields.WebargsNested(
+            {"id": fields.Int(), "name": fields.Str()}, many=True
+        )
     }
     return parser.parse(args)
 

--- a/tests/apps/django_app/echo/views.py
+++ b/tests/apps/django_app/echo/views.py
@@ -144,14 +144,18 @@ def echo_file(request):
 
 @handle_view_errors
 def echo_nested(request):
-    argmap = {"name": fields.Nested({"first": fields.Str(), "last": fields.Str()})}
+    argmap = {
+        "name": fields.WebargsNested({"first": fields.Str(), "last": fields.Str()})
+    }
     return json_response(parser.parse(argmap, request))
 
 
 @handle_view_errors
 def echo_nested_many(request):
     argmap = {
-        "users": fields.Nested({"id": fields.Int(), "name": fields.Str()}, many=True)
+        "users": fields.WebargsNested(
+            {"id": fields.Int(), "name": fields.Str()}, many=True
+        )
     }
     return json_response(parser.parse(argmap, request))
 

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -134,14 +134,16 @@ class EchoCookie:
 
 class EchoNested:
     def on_post(self, req, resp):
-        args = {"name": fields.Nested({"first": fields.Str(), "last": fields.Str()})}
+        args = {
+            "name": fields.WebargsNested({"first": fields.Str(), "last": fields.Str()})
+        }
         resp.body = json.dumps(parser.parse(args, req))
 
 
 class EchoNestedMany:
     def on_post(self, req, resp):
         args = {
-            "users": fields.Nested(
+            "users": fields.WebargsNested(
                 {"id": fields.Int(), "name": fields.Str()}, many=True
             )
         }

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -152,14 +152,16 @@ def echo_view_arg_with_use_args(args, **kwargs):
 
 @app.route("/echo_nested", methods=["POST"])
 def echo_nested():
-    args = {"name": fields.Nested({"first": fields.Str(), "last": fields.Str()})}
+    args = {"name": fields.WebargsNested({"first": fields.Str(), "last": fields.Str()})}
     return J(parser.parse(args))
 
 
 @app.route("/echo_nested_many", methods=["POST"])
 def echo_nested_many():
     args = {
-        "users": fields.Nested({"id": fields.Int(), "name": fields.Str()}, many=True)
+        "users": fields.WebargsNested(
+            {"id": fields.Int(), "name": fields.Str()}, many=True
+        )
     }
     return J(parser.parse(args))
 
@@ -167,7 +169,9 @@ def echo_nested_many():
 @app.route("/echo_nested_many_data_key", methods=["POST"])
 def echo_nested_many_with_data_key():
     args = {
-        "x_field": fields.Nested({"id": fields.Int()}, many=True, data_key="X-Field")
+        "x_field": fields.WebargsNested(
+            {"id": fields.Int()}, many=True, data_key="X-Field"
+        )
     }
     return J(parser.parse(args))
 

--- a/tests/apps/pyramid_app.py
+++ b/tests/apps/pyramid_app.py
@@ -130,13 +130,17 @@ def echo_file(request):
 
 
 def echo_nested(request):
-    argmap = {"name": fields.Nested({"first": fields.Str(), "last": fields.Str()})}
+    argmap = {
+        "name": fields.WebargsNested({"first": fields.Str(), "last": fields.Str()})
+    }
     return parser.parse(argmap, request)
 
 
 def echo_nested_many(request):
     argmap = {
-        "users": fields.Nested({"id": fields.Int(), "name": fields.Str()}, many=True)
+        "users": fields.WebargsNested(
+            {"id": fields.Int(), "name": fields.Str()}, many=True
+        )
     }
     return parser.parse(argmap, request)
 

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -109,7 +109,7 @@ class TestJSONArgs:
     def test_it_should_get_multiple_nested_values(self):
         class CustomSchema(ma.Schema):
             works = fields.List(
-                fields.Nested({"author": fields.Str(), "workname": fields.Str()})
+                fields.WebargsNested({"author": fields.Str(), "workname": fields.Str()})
             )
 
         custom_schema = CustomSchema()


### PR DESCRIPTION
This renames the existing `Nested` subclass in `webargs.fields` to `WebargsNested`. This allows type checkers to identify it as a
different type from `Nested` (and therefore not throw errors when a dict is passed), and helps clarify that we have slightly modified `Nested`.

In order to remain compatible with existing code which uses `Nested` to handle dicts, a new `Nested` class is defined which throws a DeprecationWarning when used on a `dict`.

The end result is that any usage of `Nested` which would work with `marshmallow.fields.Nested` will not warn. Conversely, any usage which is not allowed (the dict usage) will warn. We should be able to remove the `Nested` class from `webargs.fields` in a future major release.

All internal docs and test apps are updated to use `WebargsNested`.
The new `Nested` shim is not publicly documented, as it should only be needed for compatibility. There is a small note added to the `WebargsNested` docstring stating that it used to be named `Nested`. This should help alleviate confusion when users are reading code which still uses `webargs.fields.Nested({...})` and referencing the latest docs.

resolves #677

---

I'm still (more than) happy to go with a different name, or to ditch this PR and take a different approach. It seems that `mypy` can't be convinced that `webargs.fields.Nested` takes a dict -- I tried type annotating `__init__` and it still showed errors on `Nested` usage -- so I want to do something.

Probably the trickiest part of this, IMO, was figuring out how to do it such that the docs don't become confusing. The note in `WebargsNested` and no direct mention of the `Nested` redefinition is the best I came up with.