### PR TITLE
Remove 'lint' from azure-pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ jobs:
 - template: job--python-tox.yml@sloria
   parameters:
     toxenvs:
-      - lint
       - mypy
       - py37
       - py37-mindeps


### PR DESCRIPTION
With pre-commit.ci , it should not be necessary to run this job in Azure Pipelines.

---

This is a very simple change, meant in part to trigger the pre-commit.ci integration and make sure that it works.