### PR TITLE
Pin markupsafe and itsdangerous in mindeps build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,12 @@ extras = tests
 deps =
     !marshmallowdev: marshmallow>=3.0.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
-    mindeps: Flask==0.12.5
+# for 'mindeps', list flask dependencies to ensure a successful install
+# because flask 1.x does not set upper bounds on the versions of its pallets dependencies
+    mindeps: Flask==1.0.4
+    mindeps: markupsafe==1.1.1
+    mindeps: itsdangerous==1.1.0
+# all non-flask frameworks
     mindeps: Django==2.2.0
     mindeps: bottle==0.12.13
     mindeps: tornado==4.5.2

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,19 @@ extras = tests
 deps =
     !marshmallowdev: marshmallow>=3.0.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
-# for 'mindeps', list flask dependencies to ensure a successful install
-# because flask 1.x does not set upper bounds on the versions of its pallets dependencies
-    mindeps: Flask==1.0.4
+
+# for 'mindeps', pin flask to 1.1.3 and markupsafe to 1.1.1
+# because flask 1.x does not set upper bounds on the versions of its dependencies
+# generally, we can't install just any version from 1.x -- only 1.1.3 and 1.1.4
+# markupsafe is a second-order dependency of flask (flask -> jinja2 -> markupsafe)
+# and must be pinned explicitly because jinja2 does not pin its dependencies in any
+# versions in its 2.x line
+# see:
+#   https://github.com/marshmallow-code/webargs/pull/694
+#   https://github.com/pallets/flask/pull/4047
+#   https://github.com/pallets/flask/issues/4455
+    mindeps: flask==1.1.3
     mindeps: markupsafe==1.1.1
-    mindeps: itsdangerous==1.1.0
 # all non-flask frameworks
     mindeps: Django==2.2.0
     mindeps: bottle==0.12.13


### PR DESCRIPTION
Because `flask` does not pin its dependencies, it is necessary to include at least some pins when trying to install any version other than the latest. A comment in the tox config explains this briefly.

In order to also creep forward the lowest supported version (0.12.5 is *very* old), use one of the earlier flask 1.x releases, along with versions of markupsafe and itsdangerous which are approximately contemporaneous with it.

Whether or not these versions are the best choice, this set works and should get the build passing again.

---

We don't publicly announce what versions of the various frameworks we support, but this change at least makes sure we're testing on "flask 1.x" .

As a bit of separate follow-up, I've long been somewhat "low key nervous" about the fact that we install all of the frameworks in a single env for our tests. I want to look at turning that into a matrix in tox, with each framework as a factor, to see if it works out nicely. I might look at that after the GitHub Actions change.