### PR TITLE
Remove testpypi publish support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,11 +58,5 @@ jobs:
         run: python -m build
       - name: check package metadata
         run: twine check dist/*
-      # tags starting with 'testpypi-' publish to test pypi
-      # those without that prefix publish to production pypi
-      - if: startsWith(github.ref, 'refs/tags/testpypi-')
-        name: publish to testpypi
-        run: twine upload --repository testpypi -u __token__ -p ${{ secrets.TEST_PYPI_API_TOKEN }} dist/*
-      - if: ${{ ! startsWith(github.ref, 'refs/tags/testpypi-') }}
-        name: publish
+      - name: publish
         run: twine upload -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} dist/*


### PR DESCRIPTION
I just tried this out with the `testpypi-8.1.1` tag, and it worked!
![image](https://user-images.githubusercontent.com/1300022/156447465-da19a6b6-1f35-4378-8298-c63ac1fd2a46.png)

If you open up that build output, `release` pushed to testpypi as intended.

Now that the pipeline has been tested, there's no need for a variant which publishes to testpypi. I'd be fine with keeping it around, but it may just end up being something to trip over in the future.

---

I'm going to delete the `testpypi-8.1.1` tag when/if this merges, unless anyone has a reason that I should not do so.
(I mentioned this elsewhere, but this PR seems like a better place to discuss.)