### PR TITLE
Add a TODO comment to drop the custom Nested

### DIFF
--- a/src/webargs/fields.py
+++ b/src/webargs/fields.py
@@ -23,6 +23,13 @@ from marshmallow.fields import *  # noqa: F40
 __all__ = ["DelimitedList", "DelimitedTuple"] + ma.fields.__all__
 
 
+# TODO: remove custom `Nested` in the next major release
+#
+# the `Nested` class is only needed on versions of marshmallow prior to v3.15.0
+# in that version, `ma.fields.Nested` gained the ability to consume dict inputs
+# prior to that, this subclass adds this capability
+#
+# if we drop support for ma.__version_info__ < (3, 15) we can do this
 class Nested(ma.fields.Nested):  # type: ignore[no-redef]
     """Same as `marshmallow.fields.Nested`, except can be passed a dictionary as
     the first argument, which will be converted to a `marshmallow.Schema`.


### PR DESCRIPTION
I don't know when we'll next need to do a major release, so I want to put this comment in to try to avoid forgetting.

I also tried doing
```python
if ma.__version_info__ < (3, 15):
    class Nested(...): ...
```

That works, but strikes me as unnecessary.

---

On marshmallow>=3.15 we don't need this class. But dropping it requires updating the minimum version we use, so for now include a TODO comment.