### PR TITLE
Merge AsyncParser into Parser, completing Flask async support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,9 @@ Features:
   also async. They will call the non-async ``parse`` method when used to
   decorate non-async functions.
 
-* As a result of the changes to ``webargs.Parser``, ``FlaskParser`` now
-  supports async views. Thanks :user:`Isira-Seneviratne` for the PR.
+* As a result of the changes to ``webargs.Parser``, ``FlaskParser``,
+  ``DjangoParser``, and ``FalconParser`` now all support async views.
+  Thanks :user:`Isira-Seneviratne` for the initial PR.
 
 Changes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,29 @@
 Changelog
 ---------
 
-8.1.1 (Unreleased)
+8.2.0 (Unreleased)
 ******************
 
+Features:
+
+* A new method, ``webargs.Parser.async_parse``, can be used for async-aware
+  parsing from the base parser class. This can handle async location loader
+  functions and async error handlers.
+
+* ``webargs.Parser.use_args`` and ``use_kwargs`` can now be used to decorate
+  async functions, and will use  ``async_parse`` if the decorated function is
+  also async. They will call the non-async ``parse`` method when used to
+  decorate non-async functions.
+
+* As a result of the changes to ``webargs.Parser``, ``FlaskParser`` now
+  supports async views. Thanks :user:`Isira-Seneviratne` for the PR.
+
 Changes:
+
+* The implementation of ``AsyncParser`` has changed. Now that
+  ``webargs.Parser`` has built-in support for async usage, the primary
+  purpose of ``AsyncParser`` is to redefine ``parse`` as an alias for
+  ``async_parse``
 
 * Set ``python_requires>=3.7.2`` in package metadata (:pr:`692`).
   Thanks :user:`kasium` for the PR.

--- a/docs/framework_support.rst
+++ b/docs/framework_support.rst
@@ -13,8 +13,8 @@ Flask support is available via the :mod:`webargs.flaskparser` module.
 Decorator Usage
 +++++++++++++++
 
-When using the :meth:`use_args <webargs.flaskparser.FlaskParser.use_args>` and :meth:`use_args <webargs.flaskparser.FlaskParser.use_args_async>`
-decorators, the arguments dictionary will be *before* any URL variable parameters.
+When using the :meth:`use_args <webargs.flaskparser.FlaskParser.use_args>`
+decorator, the arguments dictionary will be *before* any URL variable parameters.
 
 .. code-block:: python
 
@@ -25,13 +25,6 @@ decorators, the arguments dictionary will be *before* any URL variable parameter
     @app.route("/user/<int:uid>")
     @use_args({"per_page": fields.Int()}, location="query")
     def user_detail(args, uid):
-        return ("The user page for user {uid}, showing {per_page} posts.").format(
-            uid=uid, per_page=args["per_page"]
-        )
-
-    @app.route("/user_async/<int:uid>")
-    @use_args_async({"per_page": fields.Int()}, location="query")
-    async def user_detail_async(args, uid):
         return ("The user page for user {uid}, showing {per_page} posts.").format(
             uid=uid, per_page=args["per_page"]
         )

--- a/docs/framework_support.rst
+++ b/docs/framework_support.rst
@@ -13,7 +13,8 @@ Flask support is available via the :mod:`webargs.flaskparser` module.
 Decorator Usage
 +++++++++++++++
 
-When using the :meth:`use_args <webargs.flaskparser.FlaskParser.use_args>` decorator, the arguments dictionary will be *before* any URL variable parameters.
+When using the :meth:`use_args <webargs.flaskparser.FlaskParser.use_args>` and :meth:`use_args <webargs.flaskparser.FlaskParser.use_args_async>`
+decorators, the arguments dictionary will be *before* any URL variable parameters.
 
 .. code-block:: python
 
@@ -24,6 +25,13 @@ When using the :meth:`use_args <webargs.flaskparser.FlaskParser.use_args>` decor
     @app.route("/user/<int:uid>")
     @use_args({"per_page": fields.Int()}, location="query")
     def user_detail(args, uid):
+        return ("The user page for user {uid}, showing {per_page} posts.").format(
+            uid=uid, per_page=args["per_page"]
+        )
+
+    @app.route("/user_async/<int:uid>")
+    @use_args_async({"per_page": fields.Int()}, location="query")
+    async def user_detail_async(args, uid):
         return ("The user page for user {uid}, showing {per_page} posts.").format(
             uid=uid, per_page=args["per_page"]
         )

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -17,7 +17,7 @@ import datetime as dt
 
 from flask import Flask, jsonify
 from webargs import fields, validate
-from webargs.flaskparser import use_args, use_kwargs, use_kwargs_async
+from webargs.flaskparser import use_args, use_kwargs
 
 app = Flask(__name__)
 
@@ -42,9 +42,9 @@ def add(x, y):
 
 
 @app.route("/subtract", methods=["POST"])
-@use_kwargs_async(add_args)
+@use_kwargs(add_args)
 async def subtract(x, y):
-    """An async addition endpoint."""
+    """An async subtraction endpoint."""
     return jsonify({"result": x - y})
 
 

--- a/examples/flask_example.py
+++ b/examples/flask_example.py
@@ -9,6 +9,7 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http GET :5001/
     $ http GET :5001/ name==Ada
     $ http POST :5001/add x=40 y=2
+    $ http POST :5001/subtract x=40 y=2
     $ http POST :5001/dateadd value=1973-04-10 addend=63
     $ http POST :5001/dateadd value=2014-10-23 addend=525600 unit=minutes
 """
@@ -16,7 +17,7 @@ import datetime as dt
 
 from flask import Flask, jsonify
 from webargs import fields, validate
-from webargs.flaskparser import use_args, use_kwargs
+from webargs.flaskparser import use_args, use_kwargs, use_kwargs_async
 
 app = Flask(__name__)
 
@@ -38,6 +39,13 @@ add_args = {"x": fields.Float(required=True), "y": fields.Float(required=True)}
 def add(x, y):
     """An addition endpoint."""
     return jsonify({"result": x + y})
+
+
+@app.route("/subtract", methods=["POST"])
+@use_kwargs_async(add_args)
+async def subtract(x, y):
+    """An async addition endpoint."""
+    return jsonify({"result": x - y})
 
 
 dateadd_args = {

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ EXTRAS_REQUIRE = {
     "frameworks": FRAMEWORKS,
     "tests": [
         "pytest",
+        "pytest-asyncio",
         "webtest==3.0.0",
         "webtest-aiohttp==2.0.0",
         "pytest-aiohttp>=0.3.0",

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -1,25 +1,17 @@
 """Asynchronous request parser."""
 from __future__ import annotations
 
-import asyncio
-import functools
-import inspect
 import typing
-
-from marshmallow import Schema, ValidationError
-import marshmallow as ma
 
 from webargs import core
 
-AsyncErrorHandler = typing.Callable[..., typing.Awaitable[typing.NoReturn]]
-
 
 class AsyncParser(core.Parser):
-    """Asynchronous variant of `webargs.core.Parser`, where parsing methods may be
-    either coroutines or regular methods.
+    """Asynchronous variant of `webargs.core.Parser`.
+
+    The ``parse`` method is redefined to be ``async``.
     """
 
-    # TODO: Lots of duplication from core.Parser here. Rethink.
     async def parse(
         self,
         argmap: core.ArgMap,
@@ -35,172 +27,13 @@ class AsyncParser(core.Parser):
 
         Receives the same arguments as `webargs.core.Parser.parse`.
         """
-        req = req if req is not None else self.get_default_request()
-        location = location or self.location
-        unknown = (
-            unknown
-            if unknown != core._UNKNOWN_DEFAULT_PARAM
-            else (
-                self.unknown
-                if self.unknown != core._UNKNOWN_DEFAULT_PARAM
-                else self.DEFAULT_UNKNOWN_BY_LOCATION.get(location)
-            )
+        data = await self.async_parse(
+            argmap,
+            req,
+            location=location,
+            unknown=unknown,
+            validate=validate,
+            error_status_code=error_status_code,
+            error_headers=error_headers,
         )
-        load_kwargs: dict[str, typing.Any] = {"unknown": unknown} if unknown else {}
-        if req is None:
-            raise ValueError("Must pass req object")
-        data = None
-        validators = core._ensure_list_of_callables(validate)
-        schema = self._get_schema(argmap, req)
-        try:
-            location_data = await self._load_location_data(
-                schema=schema, req=req, location=location
-            )
-            data = schema.load(location_data, **load_kwargs)
-            self._validate_arguments(data, validators)
-        except ma.exceptions.ValidationError as error:
-            await self._async_on_validation_error(
-                error,
-                req,
-                schema,
-                location,
-                error_status_code=error_status_code,
-                error_headers=error_headers,
-            )
         return data
-
-    async def _load_location_data(self, schema, req, location):
-        """Return a dictionary-like object for the location on the given request.
-
-        Needs to have the schema in hand in order to correctly handle loading
-        lists from multidict objects and `many=True` schemas.
-        """
-        loader_func = self._get_loader(location)
-        if asyncio.iscoroutinefunction(loader_func):
-            data = await loader_func(req, schema)
-        else:
-            data = loader_func(req, schema)
-
-        # when the desired location is empty (no data), provide an empty
-        # dict as the default so that optional arguments in a location
-        # (e.g. optional JSON body) work smoothly
-        if data is core.missing:
-            data = {}
-        return data
-
-    async def _async_on_validation_error(
-        self,
-        error: ValidationError,
-        req: core.Request,
-        schema: Schema,
-        location: str,
-        *,
-        error_status_code: int | None,
-        error_headers: typing.Mapping[str, str] | None,
-    ) -> typing.NoReturn:
-        # rewrite messages to be namespaced under the location which created
-        # them
-        # e.g. {"json":{"foo":["Not a valid integer."]}}
-        #      instead of
-        #      {"foo":["Not a valid integer."]}
-        error.messages = {location: error.messages}
-        error_handler = self.error_callback or self.handle_error
-        # an async error handler was registered, await it
-        if inspect.iscoroutinefunction(error_handler):
-            async_error_handler = typing.cast(AsyncErrorHandler, error_handler)
-            await async_error_handler(
-                error,
-                req,
-                schema,
-                error_status_code=error_status_code,
-                error_headers=error_headers,
-            )
-            # workaround for mypy not understanding `await Awaitable[NoReturn]`
-            # see: https://github.com/python/mypy/issues/8974
-            raise NotImplementedError("unreachable")
-        # the error handler was synchronous (e.g. Parser.handle_error) so it
-        # will raise an error
-        else:
-            error_handler(
-                error,
-                req,
-                schema,
-                error_status_code=error_status_code,
-                error_headers=error_headers,
-            )
-
-    def use_args(
-        self,
-        argmap: core.ArgMap,
-        req: core.Request | None = None,
-        *,
-        location: str = None,
-        unknown=core._UNKNOWN_DEFAULT_PARAM,
-        as_kwargs: bool = False,
-        validate: core.ValidateArg = None,
-        error_status_code: int | None = None,
-        error_headers: typing.Mapping[str, str] | None = None,
-    ) -> typing.Callable[..., typing.Callable]:
-        """Decorator that injects parsed arguments into a view function or method.
-
-        Receives the same arguments as `webargs.core.Parser.use_args`.
-        """
-        location = location or self.location
-        request_obj = req
-        # Optimization: If argmap is passed as a dictionary, we only need
-        # to generate a Schema once
-        if isinstance(argmap, dict):
-            argmap = self.schema_class.from_dict(argmap)()
-
-        def decorator(func: typing.Callable) -> typing.Callable:
-            req_ = request_obj
-
-            if inspect.iscoroutinefunction(func):
-
-                @functools.wraps(func)
-                async def wrapper(*args, **kwargs):
-                    req_obj = req_
-
-                    if not req_obj:
-                        req_obj = self.get_request_from_view_args(func, args, kwargs)
-                    # NOTE: At this point, argmap may be a Schema, callable, or dict
-                    parsed_args = await self.parse(
-                        argmap,
-                        req=req_obj,
-                        location=location,
-                        unknown=unknown,
-                        validate=validate,
-                        error_status_code=error_status_code,
-                        error_headers=error_headers,
-                    )
-                    args, kwargs = self._update_args_kwargs(
-                        args, kwargs, parsed_args, as_kwargs
-                    )
-                    return await func(*args, **kwargs)
-
-            else:
-
-                @functools.wraps(func)  # type: ignore
-                def wrapper(*args, **kwargs):
-                    req_obj = req_
-
-                    if not req_obj:
-                        req_obj = self.get_request_from_view_args(func, args, kwargs)
-                    # NOTE: At this point, argmap may be a Schema, callable, or dict
-                    parsed_args = yield from self.parse(  # type: ignore
-                        argmap,
-                        req=req_obj,
-                        location=location,
-                        unknown=unknown,
-                        validate=validate,
-                        error_status_code=error_status_code,
-                        error_headers=error_headers,
-                    )
-                    args, kwargs = self._update_args_kwargs(
-                        args, kwargs, parsed_args, as_kwargs
-                    )
-                    return func(*args, **kwargs)
-
-            return wrapper
-
-        return decorator

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -23,11 +23,10 @@ Example: ::
 from __future__ import annotations
 
 import flask
+import marshmallow as ma
 from werkzeug.exceptions import HTTPException
 
-import marshmallow as ma
-
-from webargs import core
+from webargs import core, asyncparser
 
 
 def abort(http_status_code, exc=None, **kwargs):
@@ -117,6 +116,18 @@ class FlaskParser(core.Parser):
         return flask.request
 
 
+class FlaskAsyncParser(FlaskParser, asyncparser.AsyncParser):
+    """Flask request argument parser for async views (supported on Flask
+    2.0 and higher).
+    """
+
+    pass
+
+
 parser = FlaskParser()
+async_parser = FlaskAsyncParser()
+
 use_args = parser.use_args
+use_args_async = async_parser.use_args
 use_kwargs = parser.use_kwargs
+use_kwargs_async = async_parser.use_kwargs

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -121,8 +121,6 @@ class FlaskAsyncParser(FlaskParser, asyncparser.AsyncParser):
     2.0 and higher).
     """
 
-    pass
-
 
 parser = FlaskParser()
 async_parser = FlaskAsyncParser()

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -23,10 +23,11 @@ Example: ::
 from __future__ import annotations
 
 import flask
-import marshmallow as ma
 from werkzeug.exceptions import HTTPException
 
-from webargs import core, asyncparser
+import marshmallow as ma
+
+from webargs import core
 
 
 def abort(http_status_code, exc=None, **kwargs):
@@ -116,16 +117,6 @@ class FlaskParser(core.Parser):
         return flask.request
 
 
-class FlaskAsyncParser(FlaskParser, asyncparser.AsyncParser):
-    """Flask request argument parser for async views (supported on Flask
-    2.0 and higher).
-    """
-
-
 parser = FlaskParser()
-async_parser = FlaskAsyncParser()
-
 use_args = parser.use_args
-use_args_async = async_parser.use_args
 use_kwargs = parser.use_kwargs
-use_kwargs_async = async_parser.use_kwargs

--- a/tests/apps/django_app/__init__.py
+++ b/tests/apps/django_app/__init__.py
@@ -1,0 +1,4 @@
+from django import __version__
+
+DJANGO_MAJOR_VERSION = int(__version__.split(".")[0])
+DJANGO_SUPPORTS_ASYNC = DJANGO_MAJOR_VERSION >= 3

--- a/tests/apps/django_app/base/urls.py
+++ b/tests/apps/django_app/base/urls.py
@@ -5,10 +5,12 @@ from tests.apps.django_app.echo import views
 
 urlpatterns = [
     re_path(r"^echo$", views.echo),
+    re_path(r"^async_echo$", views.async_echo),
     re_path(r"^echo_form$", views.echo_form),
     re_path(r"^echo_json$", views.echo_json),
     re_path(r"^echo_json_or_form$", views.echo_json_or_form),
     re_path(r"^echo_use_args$", views.echo_use_args),
+    re_path(r"^async_echo_use_args$", views.async_echo_use_args),
     re_path(r"^echo_use_args_validated$", views.echo_use_args_validated),
     re_path(r"^echo_ignoring_extra_data$", views.echo_ignoring_extra_data),
     re_path(r"^echo_use_kwargs$", views.echo_use_kwargs),

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -1,4 +1,5 @@
 import falcon
+import falcon.asgi
 import marshmallow as ma
 
 from webargs import fields
@@ -22,6 +23,12 @@ hello_exclude_schema = HelloSchema(unknown=ma.EXCLUDE)
 class Echo:
     def on_get(self, req, resp):
         parsed = parser.parse(hello_args, req, location="query")
+        resp.body = json.dumps(parsed)
+
+
+class AsyncEcho:
+    async def on_get(self, req, resp):
+        parsed = await parser.async_parse(hello_args, req, location="query")
         resp.body = json.dumps(parsed)
 
 
@@ -52,6 +59,12 @@ class EchoJSONOrForm:
 class EchoUseArgs:
     @use_args(hello_args, location="query")
     def on_get(self, req, resp, args):
+        resp.body = json.dumps(args)
+
+
+class AsyncEchoUseArgs:
+    @use_args(hello_args, location="query")
+    async def on_get(self, req, resp, args):
         resp.body = json.dumps(args)
 
 
@@ -187,4 +200,11 @@ def create_app():
     app.add_route("/echo_nested", EchoNested())
     app.add_route("/echo_nested_many", EchoNestedMany())
     app.add_route("/echo_use_args_hook", EchoUseArgsHook())
+    return app
+
+
+def create_async_app():
+    app = falcon.asgi.App()
+    app.add_route("/async_echo", AsyncEcho())
+    app.add_route("/async_echo_use_args", AsyncEchoUseArgs())
     return app

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -1,5 +1,4 @@
 import falcon
-import falcon.asgi
 import marshmallow as ma
 
 from webargs import fields
@@ -8,6 +7,9 @@ from webargs.falconparser import parser, use_args, use_kwargs
 
 hello_args = {"name": fields.Str(missing="World", validate=lambda n: len(n) >= 3)}
 hello_multiple = {"name": fields.List(fields.Str())}
+
+FALCON_MAJOR_VERSION = int(falcon.__version__.split(".")[0])
+FALCON_SUPPORTS_ASYNC = FALCON_MAJOR_VERSION >= 3
 
 
 class HelloSchema(ma.Schema):
@@ -204,6 +206,9 @@ def create_app():
 
 
 def create_async_app():
+    # defer import (async-capable versions only)
+    import falcon.asgi
+
     app = falcon.asgi.App()
     app.add_route("/async_echo", AsyncEcho())
     app.add_route("/async_echo_use_args", AsyncEchoUseArgs())

--- a/tests/test_djangoparser.py
+++ b/tests/test_djangoparser.py
@@ -1,5 +1,6 @@
 import pytest
 from tests.apps.django_app.base.wsgi import application
+from tests.apps.django_app import DJANGO_SUPPORTS_ASYNC
 
 from webargs.testing import CommonTestCase
 
@@ -28,8 +29,14 @@ class TestDjangoParser(CommonTestCase):
         res = testapp.get("/echo_use_args_with_path_param_cbv/42?name=Fred")
         assert res.json == {"name": "Fred"}
 
+    @pytest.mark.skipif(
+        not DJANGO_SUPPORTS_ASYNC, reason="requires a django version with async support"
+    )
     def test_parse_querystring_args_async(self, testapp):
         assert testapp.get("/async_echo?name=Fred").json == {"name": "Fred"}
 
+    @pytest.mark.skipif(
+        not DJANGO_SUPPORTS_ASYNC, reason="requires a django version with async support"
+    )
     def test_async_use_args_decorator(self, testapp):
         assert testapp.get("/async_echo_use_args?name=Fred").json == {"name": "Fred"}

--- a/tests/test_djangoparser.py
+++ b/tests/test_djangoparser.py
@@ -27,3 +27,9 @@ class TestDjangoParser(CommonTestCase):
     def test_use_args_in_class_based_view_with_path_param(self, testapp):
         res = testapp.get("/echo_use_args_with_path_param_cbv/42?name=Fred")
         assert res.json == {"name": "Fred"}
+
+    def test_parse_querystring_args_async(self, testapp):
+        assert testapp.get("/async_echo?name=Fred").json == {"name": "Fred"}
+
+    def test_async_use_args_decorator(self, testapp):
+        assert testapp.get("/async_echo_use_args?name=Fred").json == {"name": "Fred"}

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -2,7 +2,7 @@ import pytest
 import falcon.testing
 
 from webargs.testing import CommonTestCase
-from tests.apps.falcon_app import create_app, create_async_app
+from tests.apps.falcon_app import create_app, create_async_app, FALCON_SUPPORTS_ASYNC
 
 
 class TestFalconParser(CommonTestCase):
@@ -73,11 +73,17 @@ class TestFalconParser(CommonTestCase):
         )
         assert res.json == {"name": "Fred"}
 
+    @pytest.mark.skipif(
+        not FALCON_SUPPORTS_ASYNC, reason="requires a falcon version with async support"
+    )
     def test_parse_querystring_args_async(self):
         app = create_async_app()
         client = falcon.testing.TestClient(app)
         assert client.simulate_get("/async_echo?name=Fred").json == {"name": "Fred"}
 
+    @pytest.mark.skipif(
+        not FALCON_SUPPORTS_ASYNC, reason="requires a falcon version with async support"
+    )
     def test_async_use_args_decorator(self):
         app = create_async_app()
         client = falcon.testing.TestClient(app)

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -2,7 +2,7 @@ import pytest
 import falcon.testing
 
 from webargs.testing import CommonTestCase
-from tests.apps.falcon_app import create_app
+from tests.apps.falcon_app import create_app, create_async_app
 
 
 class TestFalconParser(CommonTestCase):
@@ -72,3 +72,15 @@ class TestFalconParser(CommonTestCase):
             json={"name": "Fred"},
         )
         assert res.json == {"name": "Fred"}
+
+    def test_parse_querystring_args_async(self):
+        app = create_async_app()
+        client = falcon.testing.TestClient(app)
+        assert client.simulate_get("/async_echo?name=Fred").json == {"name": "Fred"}
+
+    def test_async_use_args_decorator(self):
+        app = create_async_app()
+        client = falcon.testing.TestClient(app)
+        assert client.simulate_get("/async_echo_use_args?name=Fred").json == {
+            "name": "Fred"
+        }

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -6,10 +6,10 @@ import pytest
 from marshmallow import Schema
 from flask import Flask
 from webargs import fields, ValidationError, missing
-from webargs.flaskparser import parser, abort, async_parser
+from webargs.flaskparser import parser, abort
 from webargs.core import json
 
-from .apps.flask_app import app
+from .apps.flask_app import app, FLASK_SUPPORTS_ASYNC
 from webargs.testing import CommonTestCase
 
 
@@ -71,32 +71,53 @@ class TestFlaskAsyncParser(CommonTestCase):
     def create_app(self):
         return app
 
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_parsing_view_args_async(self, testapp):
         res = testapp.get("/echo_view_arg_async/42")
         assert res.json == {"view_arg": 42}
 
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_parsing_invalid_view_arg_async(self, testapp):
         res = testapp.get("/echo_view_arg_async/foo", expect_errors=True)
         assert res.status_code == 422
         assert res.json == {"view_args": {"view_arg": ["Not a valid integer."]}}
 
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_use_args_with_view_args_parsing_async(self, testapp):
         res = testapp.get("/echo_view_arg_use_args_async/42")
         assert res.json == {"view_arg": 42}
 
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_use_args_on_a_method_view_async(self, testapp):
         res = testapp.post_json("/echo_method_view_use_args_async", {"val": 42})
         assert res.json == {"val": 42}
 
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_use_kwargs_on_a_method_view_async(self, testapp):
         res = testapp.post_json("/echo_method_view_use_kwargs_async", {"val": 42})
         assert res.json == {"val": 42}
 
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_use_kwargs_with_missing_data_async(self, testapp):
         res = testapp.post_json("/echo_use_kwargs_missing_async", {"username": "foo"})
         assert res.json == {"username": "foo"}
 
     # regression test for https://github.com/marshmallow-code/webargs/issues/145
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_nested_many_with_data_key_async(self, testapp):
         post_with_raw_fieldname_args = (
             "/echo_nested_many_data_key_async",
@@ -114,6 +135,9 @@ class TestFlaskAsyncParser(CommonTestCase):
         assert res.json == {}
 
     # regression test for https://github.com/marshmallow-code/webargs/issues/500
+    @pytest.mark.skipif(
+        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
+    )
     def test_parsing_unexpected_headers_when_raising_async(self, testapp):
         res = testapp.get(
             "/echo_headers_raising_async",
@@ -153,31 +177,32 @@ def test_abort_called_on_validation_error(mock_abort):
 
 
 @pytest.mark.asyncio
-@mock.patch("webargs.flaskparser.abort")
-async def test_abort_called_on_validation_error_async(mock_abort):
-    # error handling must raise an error to be valid
-    mock_abort.side_effect = BadRequest("foo")
+@pytest.mark.skipif(not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask")
+async def test_abort_called_on_validation_error_async():
+    with mock.patch("webargs.flaskparser.abort") as mock_abort:
+        # error handling must raise an error to be valid
+        mock_abort.side_effect = BadRequest("foo")
 
-    app = Flask("testapp")
+        app = Flask("testapp")
 
-    def validate(x):
-        return x == 42
+        def validate(x):
+            return x == 42
 
-    argmap = {"value": fields.Field(validate=validate)}
-    with app.test_request_context(
-        "/foo",
-        method="post",
-        data=json.dumps({"value": 41}),
-        content_type="application/json",
-    ):
-        with pytest.raises(HTTPException):
-            await async_parser.parse(argmap)
-    mock_abort.assert_called()
-    abort_args, abort_kwargs = mock_abort.call_args
-    assert abort_args[0] == 422
-    expected_msg = "Invalid value."
-    assert abort_kwargs["messages"]["json"]["value"] == [expected_msg]
-    assert type(abort_kwargs["exc"]) == ValidationError
+        argmap = {"value": fields.Field(validate=validate)}
+        with app.test_request_context(
+            "/foo",
+            method="post",
+            data=json.dumps({"value": 41}),
+            content_type="application/json",
+        ):
+            with pytest.raises(HTTPException):
+                await parser.async_parse(argmap)
+        mock_abort.assert_called()
+        abort_args, abort_kwargs = mock_abort.call_args
+        assert abort_args[0] == 422
+        expected_msg = "Invalid value."
+        assert abort_kwargs["messages"]["json"]["value"] == [expected_msg]
+        assert type(abort_kwargs["exc"]) == ValidationError
 
 
 @pytest.mark.parametrize("mimetype", [None, "application/json"])

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -152,6 +152,7 @@ def test_abort_called_on_validation_error(mock_abort):
     assert type(abort_kwargs["exc"]) == ValidationError
 
 
+@pytest.mark.asyncio
 @mock.patch("webargs.flaskparser.abort")
 async def test_abort_called_on_validation_error_async(mock_abort):
     # error handling must raise an error to be valid

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -6,7 +6,7 @@ import pytest
 from marshmallow import Schema
 from flask import Flask
 from webargs import fields, ValidationError, missing
-from webargs.flaskparser import parser, abort
+from webargs.flaskparser import parser, abort, async_parser
 from webargs.core import json
 
 from .apps.flask_app import app
@@ -57,11 +57,68 @@ class TestFlaskParser(CommonTestCase):
         res = testapp.post_json("/echo_nested_many_data_key", {})
         assert res.json == {}
 
-    # regression test for
-    # https://github.com/marshmallow-code/webargs/issues/500
+    # regression test for https://github.com/marshmallow-code/webargs/issues/500
     def test_parsing_unexpected_headers_when_raising(self, testapp):
         res = testapp.get(
             "/echo_headers_raising", expect_errors=True, headers={"X-Unexpected": "foo"}
+        )
+        assert res.status_code == 422
+        assert "headers" in res.json
+        assert "X-Unexpected" in set(res.json["headers"].keys())
+
+
+class TestFlaskAsyncParser(CommonTestCase):
+    def create_app(self):
+        return app
+
+    def test_parsing_view_args_async(self, testapp):
+        res = testapp.get("/echo_view_arg_async/42")
+        assert res.json == {"view_arg": 42}
+
+    def test_parsing_invalid_view_arg_async(self, testapp):
+        res = testapp.get("/echo_view_arg_async/foo", expect_errors=True)
+        assert res.status_code == 422
+        assert res.json == {"view_args": {"view_arg": ["Not a valid integer."]}}
+
+    def test_use_args_with_view_args_parsing_async(self, testapp):
+        res = testapp.get("/echo_view_arg_use_args_async/42")
+        assert res.json == {"view_arg": 42}
+
+    def test_use_args_on_a_method_view_async(self, testapp):
+        res = testapp.post_json("/echo_method_view_use_args_async", {"val": 42})
+        assert res.json == {"val": 42}
+
+    def test_use_kwargs_on_a_method_view_async(self, testapp):
+        res = testapp.post_json("/echo_method_view_use_kwargs_async", {"val": 42})
+        assert res.json == {"val": 42}
+
+    def test_use_kwargs_with_missing_data_async(self, testapp):
+        res = testapp.post_json("/echo_use_kwargs_missing_async", {"username": "foo"})
+        assert res.json == {"username": "foo"}
+
+    # regression test for https://github.com/marshmallow-code/webargs/issues/145
+    def test_nested_many_with_data_key_async(self, testapp):
+        post_with_raw_fieldname_args = (
+            "/echo_nested_many_data_key_async",
+            {"x_field": [{"id": 42}]},
+        )
+        res = testapp.post_json(*post_with_raw_fieldname_args, expect_errors=True)
+        assert res.status_code == 422
+
+        res = testapp.post_json(
+            "/echo_nested_many_data_key_async", {"X-Field": [{"id": 24}]}
+        )
+        assert res.json == {"x_field": [{"id": 24}]}
+
+        res = testapp.post_json("/echo_nested_many_data_key_async", {})
+        assert res.json == {}
+
+    # regression test for https://github.com/marshmallow-code/webargs/issues/500
+    def test_parsing_unexpected_headers_when_raising_async(self, testapp):
+        res = testapp.get(
+            "/echo_headers_raising_async",
+            expect_errors=True,
+            headers={"X-Unexpected": "foo"},
         )
         assert res.status_code == 422
         assert "headers" in res.json
@@ -87,6 +144,33 @@ def test_abort_called_on_validation_error(mock_abort):
     ):
         with pytest.raises(HTTPException):
             parser.parse(argmap)
+    mock_abort.assert_called()
+    abort_args, abort_kwargs = mock_abort.call_args
+    assert abort_args[0] == 422
+    expected_msg = "Invalid value."
+    assert abort_kwargs["messages"]["json"]["value"] == [expected_msg]
+    assert type(abort_kwargs["exc"]) == ValidationError
+
+
+@mock.patch("webargs.flaskparser.abort")
+async def test_abort_called_on_validation_error_async(mock_abort):
+    # error handling must raise an error to be valid
+    mock_abort.side_effect = BadRequest("foo")
+
+    app = Flask("testapp")
+
+    def validate(x):
+        return x == 42
+
+    argmap = {"value": fields.Field(validate=validate)}
+    with app.test_request_context(
+        "/foo",
+        method="post",
+        data=json.dumps({"value": 41}),
+        content_type="application/json",
+    ):
+        with pytest.raises(HTTPException):
+            await async_parser.parse(argmap)
     mock_abort.assert_called()
     abort_args, abort_kwargs = mock_abort.call_args
     assert abort_args[0] == 422


### PR DESCRIPTION
I only just put this together today, so I want to share it, but also think a little more about whether or not this is a good idea. I want to read over the various framework parsers (maybe tomorrow) to see if there are any surprises which the tests don't catch. This also could impact `webargs-starlette`, so I might take a look there too.

1. Rebase #661 

2. Apply a change on top of it, https://github.com/marshmallow-code/webargs/commit/a4fe5546950e693182eae19002743263372fc02f

The idea is to combine `Parser` and `AsyncParser` into a single class (`Parser`). I think some of the code duplication we have today comes from the fact that async support isn't built into the base class.

Almost everything works out smoothly. The only odd case was that I saw some cases where the `mock.patch` decorator didn't play nicely with async tests, so those tests use the `mock.patch` context manager instead.