### PR TITLE
Always return files location data for Flask parser

### DIFF
--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -97,7 +97,7 @@ class FlaskParser(core.Parser):
 
     def load_files(self, req, schema):
         """Return files from the request as a MultiDictProxy."""
-        return self._makeproxy(req.files, schema)
+        return self._makeproxy(req.files or req.form, schema)
 
     def handle_error(self, error, req, schema, *, error_status_code, error_headers):
         """Handles errors during parsing. Aborts the current HTTP request and


### PR DESCRIPTION
When failed to parse a file, Werkzeug returns an empty dict (`ImmutableMultiDict([])`), then webargs will just return the `request.files` (empty dict), this makes it hard to do the further processes on the data (e.g. validation if the field contains a valid file object).

So I change this behavior to fall back on `request.form` when `request.files` is empty, this will make sure the `files` location always returns the data.

For example, I can make a custom `File` field like this:

```py
from werkzeug.datastructures import FileStorage
from marshmallow import Field


class File(Field):

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.metadata['type'] = 'string'
        self.metadata['format'] = 'binary'

    default_error_messages = {
        'invalid': 'Not a valid file.'
    }

    def _deserialize(self, value, attr, data, **kwargs) -> t.Any:
        if not isinstance(value, FileStorage):
            raise self.make_error('invalid')
        return value
```

fixes #720 

If this change will be approved, I will add the related tests, docs, etc.