### PR TITLE
Fix DeprecationWarning for aiohttp web exceptions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,3 +56,4 @@ Contributors (chronological)
 * Legolas Bloom `@TTWShell <https://github.com/TTWShell>`_
 * Kevin Kirsche  `@kkirsche <https://github.com/kkirsche>`_
 * Isira Seneviratne `@Isira-Seneviratne <https://github.com/Isira-Seneviratne>`_
+* Anton Ostapenko `@AVOstap <https://github.com/AVOstap>`_

--- a/src/webargs/aiohttpparser.py
+++ b/src/webargs/aiohttpparser.py
@@ -167,7 +167,7 @@ class AIOHTTPParser(AsyncParser):
             raise LookupError(f"No exception for {error_status_code}")
         headers = error_headers
         raise error_class(
-            body=json.dumps(error.messages).encode("utf-8"),
+            text=json.dumps(error.messages),
             headers=headers,
             content_type="application/json",
         )
@@ -177,9 +177,7 @@ class AIOHTTPParser(AsyncParser):
     ) -> typing.NoReturn:
         error_class = exception_map[400]
         messages = {"json": ["Invalid JSON body."]}
-        raise error_class(
-            body=json.dumps(messages).encode("utf-8"), content_type="application/json"
-        )
+        raise error_class(text=json.dumps(messages), content_type="application/json")
 
 
 parser = AIOHTTPParser()

--- a/tests/apps/aiohttp_app.py
+++ b/tests/apps/aiohttp_app.py
@@ -38,7 +38,7 @@ async def echo_json(request):
         parsed = await parser.parse(hello_args, request, location="json")
     except json.JSONDecodeError as exc:
         raise aiohttp.web.HTTPBadRequest(
-            body=json.dumps(["Invalid JSON."]).encode("utf-8"),
+            text=json.dumps(["Invalid JSON."]),
             content_type="application/json",
         ) from exc
     return json_response(parsed)
@@ -49,7 +49,7 @@ async def echo_json_or_form(request):
         parsed = await parser.parse(hello_args, request, location="json_or_form")
     except json.JSONDecodeError as exc:
         raise aiohttp.web.HTTPBadRequest(
-            body=json.dumps(["Invalid JSON."]).encode("utf-8"),
+            text=json.dumps(["Invalid JSON."]),
             content_type="application/json",
         ) from exc
     return json_response(parsed)

--- a/tests/test_aiohttpparser.py
+++ b/tests/test_aiohttpparser.py
@@ -78,6 +78,11 @@ class TestAIOHTTPParser(CommonTestCase):
             "json_parsed": {"name": "Steve"},
         }
 
+    def test_validation_error_returns_422_response(self, testapp):
+        res = testapp.post_json("/echo_json", {"name": "b"}, expect_errors=True)
+        assert res.status_code == 422
+        assert res.json == {"json": {"name": ["Invalid value."]}}
+
 
 async def test_aiohttpparser_synchronous_error_handler(web_request):
     parser = AIOHTTPParser()


### PR DESCRIPTION
Resolves https://github.com/marshmallow-code/webargs/issues/723

The fix works correctly with all versions of aiohttp starting from 3.0.8
