### PR TITLE
Set return type of `abort` to `typing.NoReturn`.

### DIFF
--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -21,6 +21,7 @@ Example: ::
         )
 """
 from __future__ import annotations
+from typing import NoReturn
 
 import flask
 from werkzeug.exceptions import HTTPException
@@ -30,7 +31,7 @@ import marshmallow as ma
 from webargs import core
 
 
-def abort(http_status_code, exc=None, **kwargs):
+def abort(http_status_code, exc=None, **kwargs) -> NoReturn:
     """Raise a HTTPException for the given http_status_code. Attach any keyword
     arguments to the exception for later processing.
 

--- a/src/webargs/flaskparser.py
+++ b/src/webargs/flaskparser.py
@@ -40,8 +40,8 @@ def abort(http_status_code, exc=None, **kwargs) -> NoReturn:
     try:
         flask.abort(http_status_code)
     except HTTPException as err:
-        err.data = kwargs
-        err.exc = exc
+        err.data = kwargs  # type: ignore
+        err.exc = exc  # type: ignore
         raise err
 
 


### PR DESCRIPTION
The `abort` function in `src/webargs/flaskparser.py` never returns, so its return type should be `typing.NoReturn`.

For comparison, the wrapped Flask `abort` function returns `typing_extensions.NoReturn`, at least as of [eb5dd9f](https://github.com/pallets/flask/commit/eb5dd9f5ef255c578cbbe13c1cb4dd11389d5519). Since `webargs` requires Python `3.7.2` or higher, it is safe to use the `typing` module's version of `NoReturn`, which was added in Python versions 3.5.4 and 3.6.2.

As for why this is important, consider this example code `example.py`:
```
from typing import Optional
from webargs.flaskparser import abort


def example(foo: Optional[str]) -> int:
    if foo is None:
        abort(400, message="string is missing")
    return len(foo)
```
Because `abort` does not return, we know that the last line of this function can only be reached if `foo` is not `None`, i.e. if it is a string. However, without the `NoReturn` return type annotation, type checkers such as mypy will not know this, and will detect the following error:
```
➜  src git:(abort-noreturn) ✗ mypy example.py
example.py:8: error: Argument 1 to "len" has incompatible type "Optional[str]"; expected "Sized"
Found 1 error in 1 file (checked 1 source file)
```

If we simply correct the return type annotation for `abort`, the error is fixed, but some new errors are surfaced:
```
➜  src git:(abort-noreturn) ✗ mypy example.py
webargs/flaskparser.py:43: error: "HTTPException" has no attribute "data"
webargs/flaskparser.py:44: error: "HTTPException" has no attribute "exc"
```

This is because annotating the return type for the `abort` function causes mypy to type-check the function's implementation. It is complaining about these lines:
```
        err.data = kwargs
        err.exc = exc
```

Therefore I have added `# type: ignore` to these two lines. Result:
```
➜  src git:(abort-noreturn) ✗ mypy example.py
Success: no issues found in 1 source file
```