### PR TITLE
Add `flask` to mypy pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,10 @@ repos:
   - id: mypy
     language_version: python3
     files: ^src/webargs/
-    additional_dependencies: ["marshmallow>=3,<4", "packaging"]
+    additional_dependencies:
+      - marshmallow>=3,<4
+      - packaging
+      - flask
 
 
 # mypy runs under tox in GitHub Actions, skip it in pre-commit.ci


### PR DESCRIPTION
`flask` is needed in order to see that `flask.abort` is a `NoReturn` function. Without this, mypy incorrectly deduces that the flaskparser `abort` function has an implicit `return None`.

This is the problem that was hit during the pre-release linting for v8.2.0 . `tox -e lint` is failing. I'm not sure why it passed when it last ran in pre-commit.ci .

Longer term, I'm inclined to remove `mypy` from pre-commit and only run it in the tox env.
But for now this is a quick/easy fix.