### PR TITLE
docs: fix simple typo, emtpy -> empty

### DIFF
--- a/src/webargs/bottleparser.py
+++ b/src/webargs/bottleparser.py
@@ -36,7 +36,7 @@ class BottleParser(core.Parser):
         except AttributeError:
             return core.missing
 
-        # unfortunately, bottle does not distinguish between an emtpy body, "",
+        # unfortunately, bottle does not distinguish between an empty body, "",
         # and a body containing the valid JSON value null, "null"
         # so these can't be properly disambiguated
         # as our best-effort solution, treat None as missing and ignore the


### PR DESCRIPTION
There is a small typo in src/webargs/bottleparser.py.

Should read `empty` rather than `emtpy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md