### PR TITLE
Only test on min/max Python versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         tox-factor: [""]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.11"]
         include:
           - python-version: "3.11"
             tox-factor: "-marshmallowdev"


### PR DESCRIPTION
We did this with Azure in #647. I guess we forgot when moving to GitHub CI.