### PR TITLE
Implement arg_name and USE_ARGS_POSITIONAL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ Features:
   over the type of the request object. Various framework-specific parsers are
   parametrized over their relevant request object classes.
 
+* ``webargs.Parser`` and its subclasses now support passing arguments as a
+  single keyword argument without expanding the parsed data into its
+  components. For more details, see advanced docs on
+  ``Argument Passing and arg_name``.
+
 Other changes:
 
 * Type annotations have been improved to allow ``Mapping`` for dict-like

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -681,6 +681,7 @@ of which are nearly identical:
     def viewfunc(query_args, json_args):
         ...
 
+
     # incorrect ordering, bottom-to-top
     @use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query")
     @use_args({"baz": fields.Str()}, location="json")
@@ -699,11 +700,14 @@ For example,
     from webargs.flaskparser import FlaskParser
     from flask import Flask
 
+
     class KeywordOnlyParser(FlaskParser):
         USE_ARGS_POSITIONAL = False
 
+
     app = Flask(__name__)
     parser = KeywordOnlyParser()
+
 
     @app.route("/")
     @parser.use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query")
@@ -718,7 +722,9 @@ parameter:
 .. code-block:: python
 
     @app.route("/")
-    @parser.use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query", arg_name="query")
+    @parser.use_args(
+        {"foo": fields.Int(), "bar": fields.Str()}, location="query", arg_name="query"
+    )
     @parser.use_args({"baz": fields.Str()}, location="json", arg_name="payload")
     def myview(*, query, payload):
         ...

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -670,8 +670,8 @@ By default, ``webargs`` provides two ways of passing arguments via decorators,
 dict-like parsed arguments into keyword arguments.
 
 For ``use_args``, the result is that sometimes it is non-obvious which order
-arguments will be passed in. Consider the following two example snippets, one
-of which are nearly identical:
+arguments will be passed in. Consider the following nearly identical example
+snippets:
 
 .. code-block:: python
 

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -51,10 +51,12 @@ _UNKNOWN_DEFAULT_PARAM = "_default"
 DEFAULT_VALIDATION_STATUS: int = 422
 
 
-def _record_arg_name(f: typing.Callable[..., typing.Any], argname: str) -> None:
+def _record_arg_name(f: typing.Callable[..., typing.Any], argname: str | None) -> None:
+    if argname is None:
+        return
     if not hasattr(f, "__webargs_argnames__"):
-        f.__webargs_argnames__ = []  # type: ignore[attr-defined]
-    f.__webargs_argnames__.append(argname)  # type: ignore[attr-defined]
+        f.__webargs_argnames__ = ()  # type: ignore[attr-defined]
+    f.__webargs_argnames__ += (argname,)  # type: ignore[attr-defined]
 
 
 def _iscallable(x) -> bool:
@@ -579,14 +581,13 @@ class Parser(typing.Generic[Request]):
             # check at decoration time that a unique name is being used
             # (no arg_name conflicts)
             if arg_name is not None and not as_kwargs:
-                existing_arg_names = getattr(func, "__webargs_argnames__", [])
+                existing_arg_names = getattr(func, "__webargs_argnames__", ())
                 if arg_name in existing_arg_names:
                     raise ValueError(
                         f"Attempted to pass `arg_name='{arg_name}'` via use_args() but "
                         "that name was already used. If this came from stacked webargs "
                         "decorators, try setting `arg_name` to distinguish usages."
                     )
-                _record_arg_name(func, arg_name)
 
             if asyncio.iscoroutinefunction(func):
 
@@ -635,6 +636,7 @@ class Parser(typing.Generic[Request]):
                     return func(*args, **kwargs)
 
             wrapper.__wrapped__ = func  # type: ignore
+            _record_arg_name(wrapper, arg_name)
             return wrapper
 
         return decorator


### PR DESCRIPTION
These features allow `use_args` to pass parsed data as keyword arguments without expanding, as `as_kwargs=True`/`use_kwargs` does. This allows for better control and clarity, especially in use-cases where decorators are stacked or may be abstracted by a framework or other tooling.

``arg_name`` functions to set the keyword argument name used for parsed data (rather than appending to positional args). ``USE_ARGS_POSITIONAL = False`` on a parser class enables implicit/automatic values for ``arg_name``, making the default behavior ``{location}_args``. With this set, for example `location="json"` will pass data as `json_args`.

---

These changes and the associated docs address most of #830, but they're intentionally geared towards supporting that use case in v8 and then changing the default behavior to clean up in v9.