### PR TITLE
Make Parser a generic type over Request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,19 @@ Changelog
 8.3.0 (unreleased)
 ******************
 
+Features:
+
+* ``webargs.Parser`` now inherits from ``typing.Generic`` and is parametrizable
+  over the type of the request object. Various framework-specific parsers are
+  parametrized over their relevant request object classes.
+
 Other changes:
 
-- Test against Python 3.11 (:pr:`787`).
+* Type annotations have been improved to allow ``Mapping`` for dict-like
+  schemas where previously ``dict`` was used. This makes the type covariant
+  rather than invariant (:issue:`836`).
+
+* Test against Python 3.11 (:pr:`787`).
 
 8.2.0 (2022-07-11)
 ******************

--- a/src/webargs/aiohttpparser.py
+++ b/src/webargs/aiohttpparser.py
@@ -70,7 +70,7 @@ _find_exceptions()
 del _find_exceptions
 
 
-class AIOHTTPParser(AsyncParser):
+class AIOHTTPParser(AsyncParser[web.Request]):
     """aiohttp request argument parser."""
 
     DEFAULT_UNKNOWN_BY_LOCATION: dict[str, str | None] = {

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -6,7 +6,7 @@ import typing
 from webargs import core
 
 
-class AsyncParser(core.Parser):
+class AsyncParser(core.Parser[core.Request]):
     """Asynchronous variant of `webargs.core.Parser`.
 
     The ``parse`` method is redefined to be ``async``.

--- a/src/webargs/bottleparser.py
+++ b/src/webargs/bottleparser.py
@@ -21,7 +21,7 @@ import bottle
 from webargs import core
 
 
-class BottleParser(core.Parser):
+class BottleParser(core.Parser[bottle.Request]):
     """Bottle.py request argument parser."""
 
     def _handle_invalid_json_error(self, error, req, *args, **kwargs):

--- a/src/webargs/djangoparser.py
+++ b/src/webargs/djangoparser.py
@@ -17,6 +17,8 @@ Example usage: ::
         def get(self, args, request):
             return HttpResponse('Hello ' + args['name'])
 """
+import django
+
 from webargs import core
 
 
@@ -24,7 +26,7 @@ def is_json_request(req):
     return core.is_json(req.content_type)
 
 
-class DjangoParser(core.Parser):
+class DjangoParser(core.Parser[django.http.HttpRequest]):
     """Django request argument parser.
 
     .. warning::
@@ -35,7 +37,7 @@ class DjangoParser(core.Parser):
         the parser and returning the appropriate `HTTPResponse`.
     """
 
-    def _raw_load_json(self, req):
+    def _raw_load_json(self, req: django.http.HttpRequest):
         """Read a json payload from the request for the core parser's load_json
 
         Checks the input mimetype and may return 'missing' if the mimetype is
@@ -45,25 +47,25 @@ class DjangoParser(core.Parser):
 
         return core.parse_json(req.body)
 
-    def load_querystring(self, req, schema):
+    def load_querystring(self, req: django.http.HttpRequest, schema):
         """Return query params from the request as a MultiDictProxy."""
         return self._makeproxy(req.GET, schema)
 
-    def load_form(self, req, schema):
+    def load_form(self, req: django.http.HttpRequest, schema):
         """Return form values from the request as a MultiDictProxy."""
         return self._makeproxy(req.POST, schema)
 
-    def load_cookies(self, req, schema):
+    def load_cookies(self, req: django.http.HttpRequest, schema):
         """Return cookies from the request."""
         return req.COOKIES
 
-    def load_headers(self, req, schema):
+    def load_headers(self, req: django.http.HttpRequest, schema):
         """Return headers from the request."""
         # Django's HttpRequest.headers is a case-insensitive dict type, but it
         # isn't a multidict, so this is not proxied
         return req.headers
 
-    def load_files(self, req, schema):
+    def load_files(self, req: django.http.HttpRequest, schema):
         """Return files from the request as a MultiDictProxy."""
         return self._makeproxy(req.FILES, schema)
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands = pre-commit run --all-files
 # `webargs` and `marshmallow` both installed is a valuable safeguard against
 # issues in which `mypy` running on every file standalone won't catch things
 [testenv:mypy]
-deps = mypy==0.930
+deps = mypy==1.3.0
 extras = frameworks
 commands = mypy src/
 


### PR DESCRIPTION
`webargs.core.Request` was declared as a TypeVar but then never bound to a relevant class-scope. As a result, it effectively evaluated as `Any` in all contexts.
Not only does this make typing less useful for us within webargs, it also means that users have a less clear typing contract to satisfy.

To resolve this, `Request` needs to be bound to the Parser class scope by means of the class becoming `Generic[Request]`. Subsequent to this, it becomes possible to add the relevant Request class for each framework parser as part of the type definition.

Throughout parser methods, like location loaders, every usage of the request object can be annotated with `webargs.core.Request`. This means the same thing as the relevant concrete request type for the framework parsers.

Finally, having made this change, it is possible to circle back to issue #836 and make the `ArgMap` type into a `Mapping` and have its new type propagate correctly. Note that `ArgMap` is a type alias which includes the `Request` type, meaning that it is an alias which is only valid in a context where `Request` is bound -- i.e. inside of a Parser class.

As a minor behavioral tweak required by this change, when `ArgMap` is passed to `Schema.from_dict`, it must be explicitly dict-ified if it is a non-dict Mapping. `Schema.from_dict` takes a dict input explicitly, so this is needed for types to match. New tests ensure that we behave correctly by means of UserDict.

Bump the version of mypy listed in tox config to the latest to ensure type checking runs correctly and quickly.