### PR TITLE
Begin disallowing untyped defs, starting with `webargs.core`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,39 @@
+[mypy]
+ignore_missing_imports = true
+warn_unreachable = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+# warn_return_any = true
+warn_no_return = true
+no_implicit_optional = true
+disallow_untyped_defs = true
+
+[mypy-webargs.fields]
+disallow_untyped_defs = false
+
+[mypy-webargs.multidictproxy]
+disallow_untyped_defs = false
+
+[mypy-webargs.testing]
+disallow_untyped_defs = false
+
+[mypy-webargs.aiohttpparser]
+disallow_untyped_defs = false
+
+[mypy-webargs.bottleparser]
+disallow_untyped_defs = false
+
+[mypy-webargs.djangoparser]
+disallow_untyped_defs = false
+
+[mypy-webargs.falconparser]
+disallow_untyped_defs = false
+
+[mypy-webargs.flaskparser]
+disallow_untyped_defs = false
+
+[mypy-webargs.pyramidparser]
+disallow_untyped_defs = false
+
+[mypy-webargs.tornadoparser]
+disallow_untyped_defs = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,3 @@ license_files = LICENSE
 max-line-length = 90
 max-complexity = 18
 extend-ignore = E203,E266
-
-[mypy]
-ignore_missing_imports = true

--- a/src/webargs/asyncparser.py
+++ b/src/webargs/asyncparser.py
@@ -22,7 +22,7 @@ class AsyncParser(core.Parser[core.Request]):
         validate: core.ValidateArg = None,
         error_status_code: int | None = None,
         error_headers: typing.Mapping[str, str] | None = None,
-    ) -> typing.Mapping | None:
+    ) -> typing.Any:
         """Coroutine variant of `webargs.core.Parser`.
 
         Receives the same arguments as `webargs.core.Parser.parse`.

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands = pre-commit run --all-files
 [testenv:mypy]
 deps = mypy==1.3.0
 extras = frameworks
-commands = mypy src/
+commands = mypy src/ {posargs}
 
 [testenv:docs]
 extras = docs


### PR DESCRIPTION
This is a draft, based off of #833 (mostly so that I don't need to rebase and handle conflicts). I can rebase onto `dev` if we want to merge it independently.

---

[Set mypy to disallow_untyped_defs on core.py](https://github.com/marshmallow-code/webargs/commit/da79514c4265831db7b3ad7f4b79a22ffafe1ac9)

Enforce that all function and method definitions in webargs.core have annotations for all arguments and return values.

To make it easier to roll out stricter config, move to a mypy.ini which disables the untyped-defs check on specific modules.