### PR TITLE
Add a Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"


### PR DESCRIPTION
This will cause Dependabot to automatically update GitHub action versions (like updating `actions/checkout@v2` to `v3` in `build.yaml`).

When this merges, Dependabot will submit PRs to update the `checkout` action to v3, and `setup-python` to v4.

I've reviewed the contributing guidelines and I think that I've followed them, but please let me know if anything else is required. Thanks!