### PR TITLE
Make type annotations more complete in flaskparser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+8.3.1 (Unreleased)
+******************
+
+Changes:
+
+* Type annotations for ``FlaskParser`` have been improved
+
 8.3.0 (2023-07-10)
 ******************
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -29,9 +29,6 @@ disallow_untyped_defs = false
 [mypy-webargs.falconparser]
 disallow_untyped_defs = false
 
-[mypy-webargs.flaskparser]
-disallow_untyped_defs = false
-
 [mypy-webargs.pyramidparser]
 disallow_untyped_defs = false
 


### PR DESCRIPTION
Pretty much what the subject line says.

This is part of a series in which I plan to remove the mypy.ini rules for various modules and apply the necessary changes to pass.