### PR TITLE
Allow overriding of the the arg_name convention

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,10 @@ Features:
     default. This will allow use of fields with ``load_default`` to specify
     handling of the empty value.
 
+* The rule for default argument names has been made configurable by overriding
+  the ``get_default_arg_name`` method. This is described in the argument
+  passing documentation.
+
 Changes:
 
 * Type annotations for ``FlaskParser`` have been improved


### PR DESCRIPTION
Rather than `{location}_args` being a hardcoded behavior, allow users to subclass and override it with a custom method.

This will allow users to set alternate naming conventions in a centralized place, on their parser class. By passing the schema object to get_default_arg_name, we enable schemas which provide their own argument names to the parser.

There are some ordering considerations which make it impossible to guarantee that `get_default_arg_name` gets a schema object (rather than, e.g. a callable which returns a schema). For this first implementation, I have opted to move the call after any dict-to-schema conversion happens, so that users have fewer types they need to handle.

---

This PR addresses [this thread at the end of #830](https://github.com/marshmallow-code/webargs/issues/830#issuecomment-1655684271), but also expands to a use-case which I have and would like to support, which is making the argument names relate to the schema in some way.