### PR TITLE
Minor example improvement: support (json, status)

### DIFF
--- a/examples/schema_example.py
+++ b/examples/schema_example.py
@@ -14,9 +14,9 @@ Try the following with httpie (a cURL-like utility, http://httpie.org):
     $ http GET :5001/users/ limit==1
 """
 import functools
-from flask import Flask, request
 import random
 
+from flask import Flask, request
 from marshmallow import Schema, fields, post_dump
 from webargs.flaskparser import parser, use_kwargs
 
@@ -74,6 +74,11 @@ def use_schema(schema_cls, list_view=False, locations=None):
             # Function wrapped with use_args
             func_with_args = use_args_wrapper(func)
             ret = func_with_args(*args, **kwargs)
+
+            # support (json, status) tuples
+            if isinstance(ret, tuple) and len(ret) == 2 and isinstance(ret[1], int):
+                return schema.dump(ret[0], many=list_view), ret[1]
+
             return schema.dump(ret, many=list_view)
 
         return wrapped


### PR DESCRIPTION
- Very minor tweak to the import order (separating stdlib from non-stdlib)
- Allow a tuple of size 2 with an int in the second slot to trigger special handling

Technically you could use a schema which supports dumping tuple values, so this really isn't any better or worse than not handling this case.
But it's just an example to show what sorts of things you can do, so this may be useful for some users.

closes #888

---

Initially, WRT #888 I was going to try to allow a lot of space for a new contributor, but it's small and I'd rather close it out by doing something proactive.
Either we agree that this is a good demo/example to add -- although it's never used by the example app -- or we close this and #888 both as "wontfix".

I don't think the change is important. But if we're going to apply it, this seems to me like a reasonable version of it.
