### PR TITLE
Fix loader functon for async methods

### DIFF
--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import inspect
 import json
 import logging
 import typing
-import inspect
 
 import marshmallow as ma
 from marshmallow import ValidationError

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -5,6 +5,7 @@ import functools
 import json
 import logging
 import typing
+import inspect
 
 import marshmallow as ma
 from marshmallow import ValidationError
@@ -237,10 +238,12 @@ class Parser(typing.Generic[Request]):
         # an async variant of the _load_location_data method
         # the loader function itself may or may not be async
         loader_func = self._get_loader(location)
-        if asyncio.iscoroutinefunction(loader_func):
-            data = await loader_func(req, schema)
-        else:
-            data = loader_func(req, schema)
+
+        data = loader_func(req, schema)
+
+        if inspect.isawaitable(data):
+            return await data
+
         return data
 
     def _on_validation_error(


### PR DESCRIPTION
Working with Falcon ASGI Request, webargs has issue parsing "media" inputs, because of the [`loader_func` ](https://github.com/marshmallow-code/webargs/blob/dev/src/webargs/core.py#L239) is not waited.

The code base of `iscoroutinefunction` do not detect Falcon "media" loader as coroutine function.
```python
def iscoroutinefunction(func):
    """Return True if func is a decorated coroutine function."""
    return (inspect.iscoroutinefunction(func) or
            getattr(func, '_is_coroutine', None) is _is_coroutine)
```
Getting `loader_func`  output and checking if the result is a coroutine works better.