### PR TITLE
Fix tests for tornado+pytest issue

### DIFF
--- a/src/webargs/__init__.py
+++ b/src/webargs/__init__.py
@@ -14,8 +14,8 @@ from webargs.core import ValidationError
 __version__ = importlib.metadata.version("webargs")
 __parsed_version__ = Version(__version__)
 __version_info__: tuple[int, int, int] | tuple[int, int, int, str, int] = (
-    __parsed_version__.release
-)  # type: ignore[assignment]
+    __parsed_version__.release  # type: ignore[assignment]
+)
 if __parsed_version__.pre:
     __version_info__ += __parsed_version__.pre  # type: ignore[assignment]
 __all__ = ("ValidationError", "fields", "missing", "validate")

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -8,8 +8,8 @@ import tornado.http1connection
 import tornado.httpserver
 import tornado.httputil
 import tornado.ioloop
+import tornado.testing
 import tornado.web
-from tornado.testing import AsyncHTTPTestCase
 
 from webargs import fields, missing
 from webargs.core import json, parse_json
@@ -19,6 +19,22 @@ from webargs.tornadoparser import (
     use_args,
     use_kwargs,
 )
+
+
+class BaseAsyncTestCase(tornado.testing.AsyncHTTPTestCase):
+    # this isn't a real test case itself
+    __test__ = False
+
+    # Workaround for https://github.com/pytest-dev/pytest/issues/12263.
+    #
+    # this was suggested by one of the pytest maintainers while a patch
+    # for Tornado is pending
+    #
+    # we may need it even after the patch, since we want to support testing on
+    # older Tornado versions until we drop support for them
+    def runTest(self):
+        pass
+
 
 name = "name"
 value = "value"
@@ -460,7 +476,7 @@ echo_app = tornado.web.Application(
 )
 
 
-class TestApp(AsyncHTTPTestCase):
+class TestApp(BaseAsyncTestCase):
     def get_app(self):
         return echo_app
 
@@ -528,7 +544,7 @@ validate_app = tornado.web.Application(
 )
 
 
-class TestValidateApp(AsyncHTTPTestCase):
+class TestValidateApp(BaseAsyncTestCase):
     def get_app(self):
         return validate_app
 


### PR DESCRIPTION
These are two small fixes to get clean test runs.

I realized that even if tornado releases with the fix from pytest, we won't instantly drop support for older tornado versions. So the workaround suggested by a pytest dev is what I'm applying here.
I setup a base test class which we can tweak appropriately and set `__test__ = False` to keep pytest from trying to run tests from that class (which fails in other ways).

On my way to this, I found I needed a very minor mypy tweak, which is isolated in a separate commit.
