### PR TITLE
Improve type annotations for the pyramid and tornado parsers

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -28,6 +28,3 @@ disallow_untyped_defs = false
 
 [mypy-webargs.falconparser]
 disallow_untyped_defs = false
-
-[mypy-webargs.pyramidparser]
-disallow_untyped_defs = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,6 +31,3 @@ disallow_untyped_defs = false
 
 [mypy-webargs.pyramidparser]
 disallow_untyped_defs = false
-
-[mypy-webargs.tornadoparser]
-disallow_untyped_defs = false

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -651,7 +651,7 @@ class Parser(typing.Generic[Request]):
                     )
                     return func(*args, **kwargs)
 
-            wrapper.__wrapped__ = func  # type: ignore
+            wrapper.__wrapped__ = func
             _record_arg_name(wrapper, arg_name)
             return wrapper
 

--- a/src/webargs/tornadoparser.py
+++ b/src/webargs/tornadoparser.py
@@ -14,6 +14,8 @@ Example: ::
             self.write(response)
 """
 
+from __future__ import annotations
+
 import json
 import typing
 

--- a/src/webargs/tornadoparser.py
+++ b/src/webargs/tornadoparser.py
@@ -14,6 +14,10 @@ Example: ::
             self.write(response)
 """
 
+import json
+import typing
+
+import marshmallow as ma
 import tornado.concurrent
 import tornado.web
 from tornado.escape import _unicode
@@ -26,13 +30,13 @@ from webargs.multidictproxy import MultiDictProxy
 class HTTPError(tornado.web.HTTPError):
     """`tornado.web.HTTPError` that stores validation errors."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         self.messages = kwargs.pop("messages", {})
         self.headers = kwargs.pop("headers", None)
         super().__init__(*args, **kwargs)
 
 
-def is_json_request(req: HTTPServerRequest):
+def is_json_request(req: HTTPServerRequest) -> bool:
     content_type = req.headers.get("Content-Type")
     return content_type is not None and core.is_json(content_type)
 
@@ -43,7 +47,7 @@ class WebArgsTornadoMultiDictProxy(MultiDictProxy):
     requirements.
     """
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> typing.Any:
         try:
             value = self.data.get(key, core.missing)
             if value is core.missing:
@@ -70,7 +74,7 @@ class WebArgsTornadoCookiesMultiDictProxy(MultiDictProxy):
     Also, does not use the `_unicode` decoding step
     """
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> typing.Any:
         cookie = self.data.get(key, core.missing)
         if cookie is core.missing:
             return core.missing
@@ -82,7 +86,7 @@ class WebArgsTornadoCookiesMultiDictProxy(MultiDictProxy):
 class TornadoParser(core.Parser[HTTPServerRequest]):
     """Tornado request argument parser."""
 
-    def _raw_load_json(self, req: HTTPServerRequest):
+    def _raw_load_json(self, req: HTTPServerRequest) -> typing.Any:
         """Return a json payload from the request for the core parser's load_json
 
         Checks the input mimetype and may return 'missing' if the mimetype is
@@ -97,23 +101,23 @@ class TornadoParser(core.Parser[HTTPServerRequest]):
 
         return core.parse_json(req.body)
 
-    def load_querystring(self, req: HTTPServerRequest, schema):
+    def load_querystring(self, req: HTTPServerRequest, schema: ma.Schema) -> typing.Any:
         """Return query params from the request as a MultiDictProxy."""
         return self._makeproxy(
             req.query_arguments, schema, cls=WebArgsTornadoMultiDictProxy
         )
 
-    def load_form(self, req: HTTPServerRequest, schema):
+    def load_form(self, req: HTTPServerRequest, schema: ma.Schema) -> typing.Any:
         """Return form values from the request as a MultiDictProxy."""
         return self._makeproxy(
             req.body_arguments, schema, cls=WebArgsTornadoMultiDictProxy
         )
 
-    def load_headers(self, req: HTTPServerRequest, schema):
+    def load_headers(self, req: HTTPServerRequest, schema: ma.Schema) -> typing.Any:
         """Return headers from the request as a MultiDictProxy."""
         return self._makeproxy(req.headers, schema, cls=WebArgsTornadoMultiDictProxy)
 
-    def load_cookies(self, req: HTTPServerRequest, schema):
+    def load_cookies(self, req: HTTPServerRequest, schema: ma.Schema) -> typing.Any:
         """Return cookies from the request as a MultiDictProxy."""
         # use the specialized subclass specifically for handling Tornado
         # cookies
@@ -121,13 +125,19 @@ class TornadoParser(core.Parser[HTTPServerRequest]):
             req.cookies, schema, cls=WebArgsTornadoCookiesMultiDictProxy
         )
 
-    def load_files(self, req: HTTPServerRequest, schema):
+    def load_files(self, req: HTTPServerRequest, schema: ma.Schema) -> typing.Any:
         """Return files from the request as a MultiDictProxy."""
         return self._makeproxy(req.files, schema, cls=WebArgsTornadoMultiDictProxy)
 
     def handle_error(
-        self, error, req: HTTPServerRequest, schema, *, error_status_code, error_headers
-    ):
+        self,
+        error: ma.ValidationError,
+        req: HTTPServerRequest,
+        schema: ma.Schema,
+        *,
+        error_status_code: int | None,
+        error_headers: typing.Mapping[str, str] | None,
+    ) -> typing.NoReturn:
         """Handles errors during parsing. Raises a `tornado.web.HTTPError`
         with a 400 error.
         """
@@ -145,8 +155,12 @@ class TornadoParser(core.Parser[HTTPServerRequest]):
         )
 
     def _handle_invalid_json_error(
-        self, error, req: HTTPServerRequest, *args, **kwargs
-    ):
+        self,
+        error: json.JSONDecodeError | UnicodeDecodeError,
+        req: HTTPServerRequest,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> typing.NoReturn:
         raise HTTPError(
             400,
             log_message="Invalid JSON body.",
@@ -154,7 +168,12 @@ class TornadoParser(core.Parser[HTTPServerRequest]):
             messages={"json": ["Invalid JSON body."]},
         )
 
-    def get_request_from_view_args(self, view, args, kwargs):
+    def get_request_from_view_args(
+        self,
+        view: typing.Any,
+        args: tuple[typing.Any, ...],
+        kwargs: typing.Mapping[str, typing.Any],
+    ) -> HTTPServerRequest:
         return args[0].request
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands = pre-commit run --all-files
 # `webargs` and `marshmallow` both installed is a valuable safeguard against
 # issues in which `mypy` running on every file standalone won't catch things
 [testenv:mypy]
-deps = mypy==1.8.0
+deps = mypy==1.10.0
 extras = frameworks
 commands = mypy src/ {posargs}
 


### PR DESCRIPTION
This changeset takes a few steps towards getting rid of mypy type checking overrides, and therefore enforcing that there are annotations everywhere.
It targets the tornado and pyramid modules.

As a related change, this updates the mypy version pinned in tox.ini to the latest.
