### PR TITLE
Improve mypy checking on multidictproxy module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+Unreleased
+**********
+
+Other changes:
+
+* ``MultiDictProxy`` now inherits from ``MutableMapping`` rather than ``Mapping``.
+
 8.5.0 (2024-04-25)
 ******************
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ disallow_untyped_defs = true
 disallow_untyped_defs = false
 module = [
   "webargs.fields",
-  "webargs.multidictproxy",
   "webargs.testing",
   "webargs.aiohttpparser",
   "webargs.bottleparser",

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands = pre-commit run --all-files
 # `webargs` and `marshmallow` both installed is a valuable safeguard against
 # issues in which `mypy` running on every file standalone won't catch things
 [testenv:mypy]
-deps = mypy==1.10.0
+deps = mypy==1.11.0
 extras = frameworks
 commands = mypy src/ {posargs}
 


### PR DESCRIPTION
This change is another incremental step towards getting things passing mypy "100%" without any exemptions.
It makes some very mild runtime changes which shouldn't have any user-visible impact.

- Fix mypy to pass on the latest version
- Type annotate the MultiDictProxy class
- Add changelog note for MultiDictProxy inheritance
