### PR TITLE
Update pre-commit config, including blacken-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.4
+  rev: v0.5.5
   hooks:
     - id: ruff
     - id: ruff-format
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.0
+  rev: 0.29.1
   hooks:
     - id: check-github-workflows
     - id: check-readthedocs
@@ -13,7 +13,7 @@ repos:
   rev: 1.18.0
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==23.12.1]
+    additional_dependencies: [black==24.4.2]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.11.0
   hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -253,8 +253,7 @@ This allows usages like
     @parser.use_kwargs(
         {"q1": ma.fields.Int(), "q2": ma.fields.Int()}, location="query", unknown=ma.EXCLUDE
     )
-    def foo(q1, q2):
-        ...
+    def foo(q1, q2): ...
 
 * Defaults for ``unknown`` may be customized on parser classes via
   ``Parser.DEFAULT_UNKNOWN_BY_LOCATION``, which maps location names to values
@@ -441,15 +440,13 @@ Refactoring:
         },
         locations=("query", "headers"),
     )
-    def foo(q1, q2, h1):
-        ...
+    def foo(q1, q2, h1): ...
 
 
     # webargs 6.x
     @parser.use_args({"q1": ma.fields.Int(), "q2": ma.fields.Int()}, location="query")
     @parser.use_args({"h1": ma.fields.Int()}, location="headers")
-    def foo(q1, q2, h1):
-        ...
+    def foo(q1, q2, h1): ...
 
 * The `location_handler` decorator has been removed and replaced with
   `location_loader`. `location_loader` serves the same purpose (letting you

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -620,8 +620,7 @@ be detected as a list when unpacking query string data:
     #   ...?foo=a&foo=b
     # and treats them as ["a"] and ["a", "b"] respectively
     @parser.use_args({"foo": CustomMultiplexingField()}, location="query")
-    def show_foos(foo):
-        ...
+    def show_foos(foo): ...
 
 
 Mixing Locations
@@ -680,15 +679,13 @@ snippets:
     # correct ordering, top-to-bottom
     @use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query")
     @use_args({"baz": fields.Str()}, location="json")
-    def viewfunc(query_args, json_args):
-        ...
+    def viewfunc(query_args, json_args): ...
 
 
     # incorrect ordering, bottom-to-top
     @use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query")
     @use_args({"baz": fields.Str()}, location="json")
-    def viewfunc(json_args, query_args):
-        ...
+    def viewfunc(json_args, query_args): ...
 
 
 To resolve this ambiguity, ``webargs`` version 9 will pass arguments from
@@ -714,8 +711,7 @@ For example,
     @app.route("/")
     @parser.use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query")
     @parser.use_args({"baz": fields.Str()}, location="json")
-    def myview(*, query_args, json_args):
-        ...
+    def myview(*, query_args, json_args): ...
 
 
 You can also customize the names of passed arguments using the ``arg_name``
@@ -728,8 +724,7 @@ parameter:
         {"foo": fields.Int(), "bar": fields.Str()}, location="query", arg_name="query"
     )
     @parser.use_args({"baz": fields.Str()}, location="json", arg_name="payload")
-    def myview(*, query, payload):
-        ...
+    def myview(*, query, payload): ...
 
 Note that ``arg_name`` is available even on parsers where
 ``USE_ARGS_POSITIONAL`` is not set.
@@ -770,8 +765,7 @@ You can customize this to set different arg names. For example,
     @app.route("/")
     @parser.use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query")
     @parser.use_args({"baz": fields.Str()}, location="json")
-    def myview(*, query, body):
-        ...
+    def myview(*, query, body): ...
 
 Additionally, this makes it possible to make custom schema classes which
 provide an argument name. For example,
@@ -802,8 +796,7 @@ provide an argument name. For example,
     @app.route("/")
     @parser.use_args({"foo": fields.Int(), "bar": fields.Str()}, location="query")
     @parser.use_args(RectangleSchema, location="json")
-    def myview(*, rectangle, query_args):
-        ...
+    def myview(*, rectangle, query_args): ...
 
 
 Next Steps

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -36,8 +36,7 @@ For example
 
 
     @parser.use_args(BodySchema)
-    def foo(data):
-        ...
+    def foo(data): ...
 
 
 In this case, under webargs 7.0 the schema ``unknown`` setting of ``EXCLUDE``
@@ -51,8 +50,7 @@ pass ``unknown`` to ``use_args``, as in
 .. code-block:: python
 
     @parser.use_args(BodySchema, unknown=ma.RAISE)
-    def foo(data):
-        ...
+    def foo(data): ...
 
 Upgrading to 7.0
 ++++++++++++++++
@@ -82,15 +80,13 @@ To get identical behavior:
 
     # webargs 6.x
     @parser.use_args(MySchema)
-    def foo(args):
-        ...
+    def foo(args): ...
 
 
     # webargs 7.x
     # as a parameter to use_args or parse
     @parser.use_args(MySchema, unknown=None)
-    def foo(args):
-        ...
+    def foo(args): ...
 
 
     # webargs 7.x
@@ -100,8 +96,7 @@ To get identical behavior:
 
 
     @parser.use_args(MySchema)
-    def foo(args):
-        ...
+    def foo(args): ...
 
 Upgrading to 6.0
 ++++++++++++++++
@@ -150,15 +145,13 @@ like so:
         },
         locations=("query", "headers"),
     )
-    def foo(q1, q2, h1):
-        ...
+    def foo(q1, q2, h1): ...
 
 
     # webargs 6.x
     @parser.use_kwargs({"q1": ma.fields.Int(), "q2": ma.fields.Int()}, location="query")
     @parser.use_kwargs({"h1": ma.fields.Int()}, location="headers")
-    def foo(q1, q2, h1):
-        ...
+    def foo(q1, q2, h1): ...
 
 
 Fields No Longer Support location=...
@@ -228,8 +221,7 @@ order to filter out unknown fields. Like so:
     # this can assume that "q" is the only parameter passed, and all other
     # parameters will be ignored
     @parser.use_kwargs({"q": ma.fields.String()}, locations=("query",))
-    def foo(q):
-        ...
+    def foo(q): ...
 
 
     # webargs 6.x, Solution 1: declare a schema with Meta.unknown set
@@ -241,8 +233,7 @@ order to filter out unknown fields. Like so:
 
 
     @parser.use_kwargs(QuerySchema, location="query")
-    def foo(q):
-        ...
+    def foo(q): ...
 
 
     # webargs 6.x, Solution 2: instantiate a schema with unknown set
@@ -251,8 +242,7 @@ order to filter out unknown fields. Like so:
 
 
     @parser.use_kwargs(QuerySchema(unknown=ma.EXCLUDE), location="query")
-    def foo(q):
-        ...
+    def foo(q): ...
 
 
 This also allows usage which passes the unknown parameters through, like so:
@@ -266,8 +256,7 @@ This also allows usage which passes the unknown parameters through, like so:
 
     # will pass *all* query params through as "kwargs"
     @parser.use_kwargs(QuerySchema(unknown=ma.INCLUDE), location="query")
-    def foo(q, **kwargs):
-        ...
+    def foo(q, **kwargs): ...
 
 
 However, many types of request data are so-called "multidicts" -- dictionary-like
@@ -300,8 +289,7 @@ the data in-place. Such usages need rewrites like so:
 
 
     @use_kwargs(QuerySchema, locations=("query",))
-    def foo(q):
-        ...
+    def foo(q): ...
 
 
     # webargs 6.x
@@ -322,8 +310,7 @@ the data in-place. Such usages need rewrites like so:
 
 
     @parser.use_kwargs(QuerySchema, location="query")
-    def foo(q):
-        ...
+    def foo(q): ...
 
 
 DelimitedList Now Only Takes A String Input
@@ -339,15 +326,13 @@ for APIs which need to allow both usages, rewrites are possible like so:
     # this allows ...?x=1&x=2&x=3
     # as well as ...?x=1,2,3
     @use_kwargs({"x": webargs.fields.DelimitedList(ma.fields.Int)}, locations=("query",))
-    def foo(x):
-        ...
+    def foo(x): ...
 
 
     # webargs 6.x
     # this accepts x=1,2,3 but NOT x=1&x=2&x=3
     @use_kwargs({"x": webargs.fields.DelimitedList(ma.fields.Int)}, location="query")
-    def foo(x):
-        ...
+    def foo(x): ...
 
 
     # webargs 6.x
@@ -366,8 +351,7 @@ for APIs which need to allow both usages, rewrites are possible like so:
 
 
     @parser.use_kwargs(UnpackingDelimitedListSchema, location="query")
-    def foo(x):
-        ...
+    def foo(x): ...
 
 
 ValidationError Messages Are Namespaced Under The Location
@@ -419,14 +403,12 @@ arguments are now keyword-only and `status_code` and `headers` have been renamed
 
     # webargs 5.x
     @parser.error_handler
-    def custom_handle_error(error, req, schema, status_code, headers):
-        ...
+    def custom_handle_error(error, req, schema, status_code, headers): ...
 
 
     # webargs 6.x
     @parser.error_handler
-    def custom_handle_error(error, req, schema, *, error_status_code, error_headers):
-        ...
+    def custom_handle_error(error, req, schema, *, error_status_code, error_headers): ...
 
 
 Some Functions Take Keyword-Only Arguments Now
@@ -441,26 +423,22 @@ the changes.
 .. code-block:: python
 
     # webargs 5.x
-    def handle_error(error, req, schema, status_code, headers):
-        ...
+    def handle_error(error, req, schema, status_code, headers): ...
 
 
     # webargs 6.x
-    def handle_error(error, req, schema, *, error_status_code, error_headers):
-        ...
+    def handle_error(error, req, schema, *, error_status_code, error_headers): ...
 
 `parser.__init__` methods:
 
 .. code-block:: python
 
     # webargs 5.x
-    def __init__(self, location=None, error_handler=None, schema_class=None):
-        ...
+    def __init__(self, location=None, error_handler=None, schema_class=None): ...
 
 
     # webargs 6.x
-    def __init__(self, location=None, *, error_handler=None, schema_class=None):
-        ...
+    def __init__(self, location=None, *, error_handler=None, schema_class=None): ...
 
 `parser.parse`, `parser.use_args`, and `parser.use_kwargs` methods:
 
@@ -476,8 +454,7 @@ the changes.
         validate=None,
         error_status_code=None,
         error_headers=None,
-    ):
-        ...
+    ): ...
 
 
     # webargs 6.x
@@ -490,8 +467,7 @@ the changes.
         validate=None,
         error_status_code=None,
         error_headers=None,
-    ):
-        ...
+    ): ...
 
 
     # webargs 5.x
@@ -504,8 +480,7 @@ the changes.
         validate=None,
         error_status_code=None,
         error_headers=None,
-    ):
-        ...
+    ): ...
 
 
     # webargs 6.x
@@ -519,8 +494,7 @@ the changes.
         validate=None,
         error_status_code=None,
         error_headers=None,
-    ):
-        ...
+    ): ...
 
 
     # use_kwargs is just an alias for use_args with as_kwargs=True
@@ -530,13 +504,11 @@ and finally, the `dict2schema` function:
 .. code-block:: python
 
     # webargs 5.x
-    def dict2schema(dct, schema_class=ma.Schema):
-        ...
+    def dict2schema(dct, schema_class=ma.Schema): ...
 
 
     # webargs 6.x
-    def dict2schema(dct, *, schema_class=ma.Schema):
-        ...
+    def dict2schema(dct, *, schema_class=ma.Schema): ...
 
 
 PyramidParser Now Appends Arguments (Used To Prepend)


### PR DESCRIPTION
pre-commit.ci would have done 60% of this, but it has been
missing the `black` version listed under `blacken-docs`.

I ran `pre-commit autoupdate; updadup` to update all three of these
dependencies.
