### PR TITLE
Reduce pre-commit.ci update frequency: monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - flask
 
 
-# mypy runs under tox in GitHub Actions, skip it in pre-commit.ci
 ci:
+  # mypy runs under tox in GitHub Actions, skip it in pre-commit.ci
   skip: [mypy]
+  autoupdate_schedule: monthly


### PR DESCRIPTION
Weekly updates are noisy for the project, relative to active human-driven work.

See also: https://github.com/marshmallow-code/flask-marshmallow/pull/335
