### PR TITLE
Fix dev requirements install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,10 +103,3 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,10 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -57,3 +57,4 @@ Contributors (chronological)
 * Kevin Kirsche  `@kkirsche <https://github.com/kkirsche>`_
 * Isira Seneviratne `@Isira-Seneviratne <https://github.com/Isira-Seneviratne>`_
 * Anton Ostapenko `@AVOstap <https://github.com/AVOstap>`_
+* Tumuer `@un4gt <https://github.com/un4gt>`_

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -48,7 +48,7 @@ Setting Up for Local Development
 ::
 
     # After activating your virtualenv
-    $ pip install -e '.[dev]'
+    $ pip install -e ".[dev]"
 
 3. (Optional, but recommended) Install the pre-commit hooks, which will format and lint your git staged files.
 


### PR DESCRIPTION
The command `pip install -e '.[dev]'` results in a syntax error on some systems due to single quotes. 

In windows :

```
pip install -e '.[dev]'
ERROR: '.[dev]' is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).
```

By using double quotes (`pip install -e ".[dev]"`), the command runs successfully on all platforms, ensuring better cross-platform compatibility.
