### PR TITLE
Fix for invalid JSON handling on latest 'bottle'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 **********
 
+Bug fixes:
+
+* Fix the handling of invalid JSON bodies in the ``bottle`` parser to support
+  ``bottle`` versions ``>=0.13``.
+
 Other changes:
 
 * ``MultiDictProxy`` now inherits from ``MutableMapping`` rather than ``Mapping``.

--- a/src/webargs/bottleparser.py
+++ b/src/webargs/bottleparser.py
@@ -37,6 +37,11 @@ class BottleParser(core.Parser[bottle.Request]):
             data = req.json
         except AttributeError:
             return core.missing
+        except bottle.HTTPError as err:
+            if err.body == "Invalid JSON":
+                self._handle_invalid_json_error(err, req)
+            else:
+                raise
 
         # unfortunately, bottle does not distinguish between an empty body, "",
         # and a body containing the valid JSON value null, "null"


### PR DESCRIPTION
bottle v0.13 captures any JSON decoding errors and reraises them as an
HTTPError exception with no inner 'exception' object and a body of
'Invalid JSON'.

Catching and handling these explicitly ensures that webargs behavior
is stable on the newer version of bottle.
