### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "3.8", python: "3.8", tox: py38-marshmallow3 }
+          - { name: "3.9", python: "3.9", tox: py39-marshmallow3 }
           - { name: "3.12", python: "3.12", tox: py312-marshmallow3 }
-          - { name: "lowest", python: "3.8", tox: py38-lowest }
+          - { name: "lowest", python: "3.9", tox: py39-lowest }
           - { name: "dev", python: "3.12", tox: py312-marshmallowdev }
     steps:
       - uses: actions/checkout@v4.0.0

--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,6 @@ Install
 
     pip install -U webargs
 
-webargs supports Python >= 3.8.
-
-
 Documentation
 =============
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,7 +1,7 @@
 Install
 =======
 
-**webargs** requires Python >= 3.8. It depends on `marshmallow <https://marshmallow.readthedocs.io/en/latest/>`_ >= 3.0.0.
+**webargs** depends on `marshmallow <https://marshmallow.readthedocs.io/en/latest/>`_ >= 3.0.0.
 
 From the PyPI
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -40,7 +39,7 @@ keywords = [
   "api",
   "marshmallow",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["marshmallow>=3.0.0", "packaging>=17.0"]
 
 [project.urls]

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -28,13 +28,13 @@ __all__ = [
 Request = typing.TypeVar("Request")
 ArgMap = typing.Union[
     ma.Schema,
-    typing.Type[ma.Schema],
-    typing.Mapping[str, typing.Union[ma.fields.Field, typing.Type[ma.fields.Field]]],
+    type[ma.Schema],
+    typing.Mapping[str, typing.Union[ma.fields.Field, type[ma.fields.Field]]],
     typing.Callable[[Request], ma.Schema],
 ]
 
 ValidateArg = typing.Union[None, typing.Callable, typing.Iterable[typing.Callable]]
-CallableList = typing.List[typing.Callable]
+CallableList = list[typing.Callable]
 ErrorHandler = typing.Callable[..., typing.NoReturn]
 # generic type var with no particular meaning
 T = typing.TypeVar("T")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -75,9 +75,10 @@ def test_load_json_called_by_parse_default(load_json, web_request):
     "location", ["querystring", "form", "headers", "cookies", "files"]
 )
 def test_load_nondefault_called_by_parse_with_location(location, web_request):
-    with mock.patch(
-        f"webargs.core.Parser.load_{location}"
-    ) as mock_loadfunc, mock.patch("webargs.core.Parser.load_json") as load_json:
+    with (
+        mock.patch(f"webargs.core.Parser.load_{location}") as mock_loadfunc,
+        mock.patch("webargs.core.Parser.load_json") as load_json,
+    ):
         mock_loadfunc.return_value = {}
         load_json.return_value = {}
         p = Parser()

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist=
     lint
-    py{38,39,310,311,312}-marshmallow3
+    py{39,310,311,312}-marshmallow3
     py312-marshmallowdev
-    py38-lowest
+    py39-lowest
     docs
 
 [testenv]


### PR DESCRIPTION
Also remove Python 3.x min minor version in README and docs. Not so useful and needs to be updated on each release (which I tend to forget).