### PR TITLE
Improve type annotations; avoid runtime cost

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,12 @@ keywords = [
   "marshmallow",
 ]
 requires-python = ">=3.9"
-dependencies = ["marshmallow>=3.0.0", "packaging>=17.0"]
+dependencies = [
+    "marshmallow>=3.0.0",
+    "packaging>=17.0",
+    # depend on typing-extensions conditionally for annotations
+    'typing_extensions>=4.0; python_version<"3.10"',
+]
 
 [project.urls]
 Changelog = "https://webargs.readthedocs.io/en/latest/changelog.html"

--- a/src/webargs/_types.py
+++ b/src/webargs/_types.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+import typing
+
+import marshmallow as ma
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
+
+
+T = typing.TypeVar("T")
+
+# an arg-map is one of the following
+# - a schema
+# - a schema class
+# - a str->Field mapping
+# - a `(Request) -> Schema` callable
+ArgMapCallable: TypeAlias = typing.Callable[[T], ma.Schema]
+ArgMap: TypeAlias = typing.Union[
+    ma.Schema, type[ma.Schema], typing.Mapping[str, ma.fields.Field], ArgMapCallable[T]
+]
+
+# a 'validate' value is a callable or collection ofcallables
+ValidateArg: TypeAlias = typing.Union[
+    None, typing.Callable, typing.Iterable[typing.Callable]
+]
+CallableList: TypeAlias = list[typing.Callable[..., typing.Any]]
+
+# error handlers are no-return callables
+ErrorHandler: TypeAlias = typing.Callable[..., typing.NoReturn]
+AsyncErrorHandler: TypeAlias = typing.Callable[..., typing.Awaitable[typing.NoReturn]]

--- a/src/webargs/core.py
+++ b/src/webargs/core.py
@@ -14,6 +14,16 @@ from marshmallow.utils import missing
 
 from webargs.multidictproxy import MultiDictProxy
 
+if typing.TYPE_CHECKING:
+    from webargs._types import (
+        ArgMap,
+        ArgMapCallable,
+        AsyncErrorHandler,
+        CallableList,
+        ErrorHandler,
+        ValidateArg,
+    )
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,26 +35,19 @@ __all__ = [
 ]
 
 
+# a type var for library-provided request types
 Request = typing.TypeVar("Request")
-ArgMapCallable = typing.Callable[[Request], ma.Schema]
-ArgMap = typing.Union[
-    ma.Schema, type[ma.Schema], typing.Mapping[str, ma.fields.Field], ArgMapCallable
-]
-
-ValidateArg = typing.Union[None, typing.Callable, typing.Iterable[typing.Callable]]
-CallableList = list[typing.Callable]
-ErrorHandler = typing.Callable[..., typing.NoReturn]
 # generic type var with no particular meaning
 T = typing.TypeVar("T")
 # type var for callables, to make type-preserving decorators
-C = typing.TypeVar("C", bound=typing.Callable)
+C = typing.TypeVar("C", bound=typing.Callable[..., typing.Any])
+
 # type var for multidict proxy classes
 MultiDictProxyT = typing.TypeVar("MultiDictProxyT", bound=MultiDictProxy)
+
 # type var for a callable which is an error handler
 # used to ensure that the error_handler decorator is type preserving
-ErrorHandlerT = typing.TypeVar("ErrorHandlerT", bound=ErrorHandler)
-
-AsyncErrorHandler = typing.Callable[..., typing.Awaitable[typing.NoReturn]]
+ErrorHandlerT = typing.TypeVar("ErrorHandlerT", bound="ErrorHandler")
 
 
 # a value used as the default for arguments, so that when `None` is passed, it
@@ -117,7 +120,7 @@ def parse_json(s: typing.AnyStr, *, encoding: str = "utf-8") -> typing.Any:
 def _ensure_list_of_callables(obj: typing.Any) -> CallableList:
     if obj:
         if isinstance(obj, (list, tuple)):
-            validators = typing.cast(CallableList, list(obj))
+            validators: CallableList = list(obj)
         elif callable(obj):
             validators = [obj]
         else:
@@ -285,7 +288,7 @@ class Parser(typing.Generic[Request]):
         error_handler = self.error_callback or self.handle_error
         # an async error handler was registered, await it
         if asyncio.iscoroutinefunction(error_handler):
-            async_error_handler = typing.cast(AsyncErrorHandler, error_handler)
+            async_error_handler: AsyncErrorHandler = error_handler
             await async_error_handler(
                 error,
                 req,
@@ -312,7 +315,7 @@ class Parser(typing.Generic[Request]):
                 msg = self.DEFAULT_VALIDATION_MESSAGE
                 raise ValidationError(msg, data=data)
 
-    def _get_schema(self, argmap: ArgMap, req: Request) -> ma.Schema:
+    def _get_schema(self, argmap: ArgMap[Request], req: Request) -> ma.Schema:
         """Return a `marshmallow.Schema` for the given argmap and request.
 
         :param argmap: Either a `marshmallow.Schema`, `dict`
@@ -329,7 +332,7 @@ class Parser(typing.Generic[Request]):
             argmap_dict = argmap if isinstance(argmap, dict) else dict(argmap)
             schema = self.schema_class.from_dict(argmap_dict)()
         elif callable(argmap):
-            argmap_callable = typing.cast(ArgMapCallable, argmap)
+            argmap_callable: ArgMapCallable[Request] = argmap  # type: ignore[assignment]
             schema = argmap_callable(req)
         else:
             raise TypeError(f"argmap was of unexpected type {type(argmap)}")
@@ -337,7 +340,7 @@ class Parser(typing.Generic[Request]):
 
     def _prepare_for_parse(
         self,
-        argmap: ArgMap,
+        argmap: ArgMap[Request],
         req: Request | None = None,
         location: str | None = None,
         unknown: str | None = _UNKNOWN_DEFAULT_PARAM,
@@ -392,7 +395,7 @@ class Parser(typing.Generic[Request]):
 
     def parse(
         self,
-        argmap: ArgMap,
+        argmap: ArgMap[Request],
         req: Request | None = None,
         *,
         location: str | None = None,
@@ -451,7 +454,7 @@ class Parser(typing.Generic[Request]):
 
     async def async_parse(
         self,
-        argmap: ArgMap,
+        argmap: ArgMap[Request],
         req: Request | None = None,
         *,
         location: str | None = None,
@@ -536,7 +539,7 @@ class Parser(typing.Generic[Request]):
 
     def use_args(
         self,
-        argmap: ArgMap,
+        argmap: ArgMap[Request],
         req: Request | None = None,
         *,
         location: str | None = None,
@@ -657,7 +660,7 @@ class Parser(typing.Generic[Request]):
 
     def use_kwargs(
         self,
-        argmap: ArgMap,
+        argmap: ArgMap[Request],
         req: Request | None = None,
         *,
         location: str | None = None,
@@ -691,7 +694,7 @@ class Parser(typing.Generic[Request]):
             error_headers=error_headers,
         )
 
-    def get_default_arg_name(self, location: str, schema: ArgMap) -> str:
+    def get_default_arg_name(self, location: str, schema: ArgMap[Request]) -> str:
         """This method provides the rule by which an argument name is derived for
         :meth:`use_args` if no explicit ``arg_name`` is provided.
 

--- a/src/webargs/falconparser.py
+++ b/src/webargs/falconparser.py
@@ -38,19 +38,18 @@ def parse_form_body(req: falcon.Request):
         and "application/x-www-form-urlencoded" in req.content_type
     ):
         # the type of `req.stream.read()` is `str | Any` according to annotations
-        # but at runtime it's always `bytes`, so coerce by checking the type
+        # but at runtime it's always `bytes`, so coerce the type for type checker
         body: str | bytes | None = req.stream.read(req.content_length or 0)
-        if isinstance(body, bytes):
-            try:
-                body = body.decode("ascii")
-            except UnicodeDecodeError:
-                body = None
-                req.log_error(
-                    "Non-ASCII characters found in form body "
-                    "with Content-Type of "
-                    "application/x-www-form-urlencoded. Body "
-                    "will be ignored."
-                )
+        try:
+            body = body.decode("ascii")  # type: ignore[union-attr]
+        except UnicodeDecodeError:
+            body = None
+            req.log_error(
+                "Non-ASCII characters found in form body "
+                "with Content-Type of "
+                "application/x-www-form-urlencoded. Body "
+                "will be ignored."
+            )
 
         if body:
             return parse_query_string(body, keep_blank=req.options.keep_blank_qs_values)

--- a/src/webargs/falconparser.py
+++ b/src/webargs/falconparser.py
@@ -1,5 +1,7 @@
 """Falcon request argument parsing module."""
 
+from __future__ import annotations
+
 import falcon
 import marshmallow as ma
 from falcon.util.uri import parse_query_string
@@ -35,17 +37,20 @@ def parse_form_body(req: falcon.Request):
         req.content_type is not None
         and "application/x-www-form-urlencoded" in req.content_type
     ):
-        body = req.stream.read(req.content_length or 0)
-        try:
-            body = body.decode("ascii")
-        except UnicodeDecodeError:
-            body = None
-            req.log_error(
-                "Non-ASCII characters found in form body "
-                "with Content-Type of "
-                "application/x-www-form-urlencoded. Body "
-                "will be ignored."
-            )
+        # the type of `req.stream.read()` is `str | Any` according to annotations
+        # but at runtime it's always `bytes`, so coerce by checking the type
+        body: str | bytes | None = req.stream.read(req.content_length or 0)
+        if isinstance(body, bytes):
+            try:
+                body = body.decode("ascii")
+            except UnicodeDecodeError:
+                body = None
+                req.log_error(
+                    "Non-ASCII characters found in form body "
+                    "with Content-Type of "
+                    "application/x-www-form-urlencoded. Body "
+                    "will be ignored."
+                )
 
         if body:
             return parse_query_string(body, keep_blank=req.options.keep_blank_qs_values)


### PR DESCRIPTION
1. Add 'typing-extensions' as a conditional dependency. This allows us to import some of the newer symbols (at present, TypeAlias) both at runtime and at type-checking time.

2. Move type aliases into a generic '_types' helper module; make that module something we only even import under type checking.

3. Avoid all uses of `typing.cast` and rely on annotations+ type-ignore comments instead, as appropriate.

4. Fix the way that the 'Request' type var gets bound to 'ArgMap' and 'ArgMapCallable' types. (Our previous usage may have worked but was possibly relying on undefined type checker behaviors.)

Fix the (unrelated) detected "error" in the falcon parser.

Overall, this should take type annotations for `webargs` to a nearly 0 runtime cost. But it also improves the accuracy and maintainability of the annotations.

---

I realized that something was sort of wrong with the `ArgMap` types.
I wanted to wrangle with that and figure out how to check more accurately.
Trying to remove runtime costs was a small add-on while looking at our typing usages.

I tested using this sample to confirm that this produces the correct type annotation for `req`[^1]:

```python
# sample.py
import webargs

class MyReqType:
    pass

class MyParser(webargs.core.Parser[MyReqType]):
    pass

result = MyParser().parse({}, req=object())
```

```bash
$ mypy sample.py
sample.py:10: error: Argument "req" to "parse" of "Parser" has incompatible type "object"; expected "MyReqType | None"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

[^1]: This already works today against `dev`, so this is a regression test. But I'm not clear on whether or not our usage might stop working as typing gets more standardized, since we're a bit off-spec.

---

I re-checked and got a test case which demonstrates the improvement.

```python
# sample2.py
import marshmallow
import webargs

class MyReqType:
    pass

class MyParser(webargs.core.Parser[MyReqType]):
    pass

def dynamic_schema(foo: int) -> marshmallow.Schema:
    return marshmallow.Schema.from_dict({})()

result = MyParser().parse(dynamic_schema)
```

On `dev`, `mypy` passes on this, no errors.
With these changes:
```bash
$ mypy sample2.py       
sample2.py:14: error: Argument 1 to "parse" of "Parser" has incompatible type "Callable[[int], Schema]"; expected "Schema | type[Schema] | Mapping[str, Field[Any]] | Callable[[MyReqType], Schema]"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

Because it's able to recognize that the callable which is supposed to be of type `MyReqType -> Schema` is of type `int -> Schema`. On `dev`, the issue is that the type of that callable is written as `Request -> Schema`, but `Request` isn't properly bound, so it's _really_ `Any -> Schema`.

The typing stuff can still get me a little turned around sometimes.