### PR TITLE
Fix the bounds & testing on marshmallow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - { name: "3.9", python: "3.9", tox: py39-marshmallow3 }
           - { name: "3.13", python: "3.13", tox: py313-marshmallow3 }
+          - { name: "3.9", python: "3.9", tox: py39-marshmallow4 }
+          - { name: "3.13", python: "3.13", tox: py313-marshmallow4 }
           - { name: "lowest", python: "3.9", tox: py39-lowest }
           - { name: "dev", python: "3.13", tox: py313-marshmallowdev }
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+Unreleased
+**********
+
+Bug fixes:
+
+* Correct the package metadata for ``marshmallow`` versions which are supported
+  by ``webargs``
+
 8.7.0 (2025-04-18)
 ******************
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ keywords = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "marshmallow>=3.0.0",
+    "marshmallow>=3.13.0,<5.0.0",
     "packaging>=17.0",
     # depend on typing-extensions conditionally for annotations
     'typing_extensions>=4.0; python_version<"3.10"',

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
     lint
     py{39,310,311,312,313}-marshmallow3
+    py{39,313}-marshmallow4
     py313-marshmallowdev
     py39-lowest
     docs
@@ -10,9 +11,10 @@ envlist=
 extras = tests
 deps =
     marshmallow3: marshmallow>=3.0.0,<4.0.0
+    marshmallow4: marshmallow>=4.0.0,<5.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
 
-# for 'mindeps', pin flask to 1.1.3 and markupsafe to 1.1.1
+# for 'lowest', pin flask to 1.1.3 and markupsafe to 1.1.1
 # because flask 1.x does not set upper bounds on the versions of its dependencies
 # generally, we can't install just any version from 1.x -- only 1.1.3 and 1.1.4
 # markupsafe is a second-order dependency of flask (flask -> jinja2 -> markupsafe)
@@ -31,6 +33,8 @@ deps =
     lowest: pyramid==1.9.1
     lowest: falcon==2.0.0
     lowest: aiohttp==3.0.8
+# pin marshmallow itself to the lowest supported version
+    lowest: marshmallow==3.13.0
 commands = pytest {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
- Set a lower bound of v3.13.0 , the lowest version which passes tests
- Ensure that we test on marshmallow 3.x and 4.x in CI and tox dev
