### PR TITLE
Bump supported framework versions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,10 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "3.10", python: "3.10", tox: py310-marshmallow3 }
-          - { name: "3.14", python: "3.14", tox: py314-marshmallow3 }
-          - { name: "3.10", python: "3.10", tox: py310-marshmallow4 }
-          - { name: "3.14", python: "3.14", tox: py314-marshmallow4 }
+          - { name: "3.10", python: "3.10", tox: py310-marshmallow }
+          - { name: "3.14", python: "3.14", tox: py314-marshmallow }
           - { name: "lowest", python: "3.10", tox: py310-lowest }
           - { name: "dev", python: "3.14", tox: py314-marshmallowdev }
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ keywords = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "marshmallow>=3.13.0,<5.0.0",
+    "marshmallow>=4.0.0,<5.0.0",
     "packaging>=17.0",
     # depend on typing-extensions conditionally for annotations
     'typing_extensions>=4.0; python_version<"3.10"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,13 @@ Tidelift = "https://tidelift.com/subscription/pkg/pypi-webargs?utm_source=pypi-w
 
 [project.optional-dependencies]
 frameworks = [
-  "Flask>=0.12.5",
-  "Django>=2.2.0",
+  "Flask>=3.1.0",
+  "Django>=5.2.0",
   "bottle>=0.13.0",
-  "tornado>=6.0.0",
-  "pyramid>=1.9.1",
-  "falcon>=2.0.0",
-  "aiohttp>=3.0.8",
+  "tornado>=6.5.0",
+  "pyramid>=2.0.2",
+  "falcon>=4.1.0",
+  "aiohttp>=3.13.0",
 ]
 tests = [
   "webargs[frameworks]",

--- a/src/webargs/fields.py
+++ b/src/webargs/fields.py
@@ -1,7 +1,6 @@
 """Field classes.
 
-Includes all fields from `marshmallow.fields` in addition to a custom
-`Nested` field and `DelimitedList`.
+Includes all fields from `marshmallow.fields` in addition to `DelimitedList`.
 
 All fields can optionally take a special `location` keyword argument, which
 tells webargs where to parse the request argument from.
@@ -24,30 +23,6 @@ import marshmallow as ma
 from marshmallow.fields import *  # noqa: F403
 
 __all__ = ["DelimitedList", "DelimitedTuple"] + ma.fields.__all__
-
-
-# TODO: remove custom `Nested` in the next major release
-#
-# the `Nested` class is only needed on versions of marshmallow prior to v3.15.0
-# in that version, `ma.fields.Nested` gained the ability to consume dict inputs
-# prior to that, this subclass adds this capability
-#
-# if we drop support for ma.__version_info__ < (3, 15) we can do this
-class Nested(ma.fields.Nested):  # type: ignore[no-redef]
-    """Same as `marshmallow.fields.Nested`, except can be passed a dictionary
-    as the first argument, which will be converted to a `marshmallow.Schema`.
-
-    .. note::
-
-        The schema class here will always be `marshmallow.Schema`, regardless
-        of whether a custom schema class is set on the parser. Pass an explicit schema
-        class if necessary.
-    """
-
-    def __init__(self, nested, *args, **kwargs):
-        if isinstance(nested, dict):
-            nested = ma.Schema.from_dict(nested)
-        super().__init__(nested, *args, **kwargs)
 
 
 class DelimitedFieldMixin:

--- a/tests/apps/django_app/__init__.py
+++ b/tests/apps/django_app/__init__.py
@@ -1,4 +1,1 @@
-import importlib.metadata
 
-DJANGO_MAJOR_VERSION = int(importlib.metadata.version("django").split(".")[0])
-DJANGO_SUPPORTS_ASYNC = DJANGO_MAJOR_VERSION >= 3

--- a/tests/apps/falcon_app.py
+++ b/tests/apps/falcon_app.py
@@ -1,5 +1,3 @@
-import importlib.metadata
-
 import falcon
 import marshmallow as ma
 
@@ -9,9 +7,6 @@ from webargs.falconparser import parser, use_args, use_kwargs
 
 hello_args = {"name": fields.Str(load_default="World", validate=validate.Length(min=3))}
 hello_multiple = {"name": fields.List(fields.Str())}
-
-FALCON_MAJOR_VERSION = int(importlib.metadata.version("falcon").split(".")[0])
-FALCON_SUPPORTS_ASYNC = FALCON_MAJOR_VERSION >= 3
 
 
 class HelloSchema(ma.Schema):
@@ -25,10 +20,7 @@ hello_exclude_schema = HelloSchema(unknown=ma.EXCLUDE)
 
 
 def set_text(resp, value):
-    if FALCON_MAJOR_VERSION >= 3:
-        resp.text = value
-    else:
-        resp.body = value
+    resp.text = value
 
 
 class Echo:
@@ -191,11 +183,7 @@ class EchoUseArgsHook:
 
 
 def create_app():
-    if FALCON_MAJOR_VERSION >= 3:
-        app = falcon.App()
-    else:
-        app = falcon.API()
-
+    app = falcon.App()
     app.add_route("/echo", Echo())
     app.add_route("/echo_form", EchoForm())
     app.add_route("/echo_json", EchoJSON())

--- a/tests/apps/flask_app.py
+++ b/tests/apps/flask_app.py
@@ -1,5 +1,3 @@
-import importlib.metadata
-
 import marshmallow as ma
 from flask import Flask, Response, request
 from flask import jsonify as J
@@ -12,9 +10,6 @@ from webargs.flaskparser import (
     use_args,
     use_kwargs,
 )
-
-FLASK_MAJOR_VERSION = int(importlib.metadata.version("flask").split(".")[0])
-FLASK_SUPPORTS_ASYNC = FLASK_MAJOR_VERSION >= 2
 
 
 class TestAppConfig:
@@ -138,12 +133,10 @@ def echo_headers_raising(args):
     return J(args)
 
 
-if FLASK_SUPPORTS_ASYNC:
-
-    @app.route("/echo_headers_raising_async")
-    @use_args(HelloSchema(), location="headers", unknown=None)
-    async def echo_headers_raising_async(args):
-        return J(args)
+@app.route("/echo_headers_raising_async")
+@use_args(HelloSchema(), location="headers", unknown=None)
+async def echo_headers_raising_async(args):
+    return J(args)
 
 
 @app.route("/echo_cookie")
@@ -165,14 +158,12 @@ def echo_view_arg(view_arg):
     return J(parser.parse({"view_arg": fields.Int()}, location="view_args"))
 
 
-if FLASK_SUPPORTS_ASYNC:
-
-    @app.route("/echo_view_arg_async/<view_arg>")
-    async def echo_view_arg_async(view_arg):
-        parsed_view_arg = await parser.async_parse(
-            {"view_arg": fields.Int()}, location="view_args"
-        )
-        return J(parsed_view_arg)
+@app.route("/echo_view_arg_async/<view_arg>")
+async def echo_view_arg_async(view_arg):
+    parsed_view_arg = await parser.async_parse(
+        {"view_arg": fields.Int()}, location="view_args"
+    )
+    return J(parsed_view_arg)
 
 
 @app.route("/echo_view_arg_use_args/<view_arg>")
@@ -181,12 +172,10 @@ def echo_view_arg_with_use_args(args, **kwargs):
     return J(args)
 
 
-if FLASK_SUPPORTS_ASYNC:
-
-    @app.route("/echo_view_arg_use_args_async/<view_arg>")
-    @use_args({"view_arg": fields.Int()}, location="view_args")
-    async def echo_view_arg_with_use_args_async(args, **kwargs):
-        return J(args)
+@app.route("/echo_view_arg_use_args_async/<view_arg>")
+@use_args({"view_arg": fields.Int()}, location="view_args")
+async def echo_view_arg_with_use_args_async(args, **kwargs):
+    return J(args)
 
 
 @app.route("/echo_nested", methods=["POST"])
@@ -211,16 +200,12 @@ def echo_nested_many_with_data_key():
     return J(parser.parse(args))
 
 
-if FLASK_SUPPORTS_ASYNC:
-
-    @app.route("/echo_nested_many_data_key_async", methods=["POST"])
-    async def echo_nested_many_with_data_key_async():
-        args = {
-            "x_field": fields.Nested(
-                {"id": fields.Int()}, many=True, data_key="X-Field"
-            )
-        }
-        return J(await parser.async_parse(args))
+@app.route("/echo_nested_many_data_key_async", methods=["POST"])
+async def echo_nested_many_with_data_key_async():
+    args = {
+        "x_field": fields.Nested({"id": fields.Int()}, many=True, data_key="X-Field")
+    }
+    return J(await parser.async_parse(args))
 
 
 class EchoMethodViewUseArgs(MethodView):
@@ -235,17 +220,16 @@ app.add_url_rule(
 )
 
 
-if FLASK_SUPPORTS_ASYNC:
+class EchoMethodViewUseArgsAsync(MethodView):
+    @use_args({"val": fields.Int()})
+    async def post(self, args):
+        return J(args)
 
-    class EchoMethodViewUseArgsAsync(MethodView):
-        @use_args({"val": fields.Int()})
-        async def post(self, args):
-            return J(args)
 
-    app.add_url_rule(
-        "/echo_method_view_use_args_async",
-        view_func=EchoMethodViewUseArgsAsync.as_view("echo_method_view_use_args_async"),
-    )
+app.add_url_rule(
+    "/echo_method_view_use_args_async",
+    view_func=EchoMethodViewUseArgsAsync.as_view("echo_method_view_use_args_async"),
+)
 
 
 class EchoMethodViewUseKwargs(MethodView):
@@ -259,19 +243,17 @@ app.add_url_rule(
     view_func=EchoMethodViewUseKwargs.as_view("echo_method_view_use_kwargs"),
 )
 
-if FLASK_SUPPORTS_ASYNC:
 
-    class EchoMethodViewUseKwargsAsync(MethodView):
-        @use_kwargs({"val": fields.Int()})
-        async def post(self, val):
-            return J({"val": val})
+class EchoMethodViewUseKwargsAsync(MethodView):
+    @use_kwargs({"val": fields.Int()})
+    async def post(self, val):
+        return J({"val": val})
 
-    app.add_url_rule(
-        "/echo_method_view_use_kwargs_async",
-        view_func=EchoMethodViewUseKwargsAsync.as_view(
-            "echo_method_view_use_kwargs_async"
-        ),
-    )
+
+app.add_url_rule(
+    "/echo_method_view_use_kwargs_async",
+    view_func=EchoMethodViewUseKwargsAsync.as_view("echo_method_view_use_kwargs_async"),
+)
 
 
 @app.route("/echo_use_kwargs_missing", methods=["post"])
@@ -281,13 +263,11 @@ def echo_use_kwargs_missing(username, **kwargs):
     return J({"username": username})
 
 
-if FLASK_SUPPORTS_ASYNC:
-
-    @app.route("/echo_use_kwargs_missing_async", methods=["post"])
-    @use_kwargs({"username": fields.Str(required=True), "password": fields.Str()})
-    async def echo_use_kwargs_missing_async(username, **kwargs):
-        assert "password" not in kwargs
-        return J({"username": username})
+@app.route("/echo_use_kwargs_missing_async", methods=["post"])
+@use_kwargs({"username": fields.Str(required=True), "password": fields.Str()})
+async def echo_use_kwargs_missing_async(username, **kwargs):
+    assert "password" not in kwargs
+    return J({"username": username})
 
 
 # Return validation errors as JSON

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 import collections
 import datetime
-import importlib.metadata
 import typing
 from unittest import mock
 
@@ -16,14 +15,11 @@ from marshmallow import (
     pre_load,
     validates_schema,
 )
-from packaging.version import Version
 from werkzeug.datastructures import MultiDict as WerkMultiDict
 
 from webargs import ValidationError, fields
 from webargs.core import Parser, get_mimetype, is_json
 from webargs.multidictproxy import MultiDictProxy
-
-MARSHMALLOW_VERSION = Version(importlib.metadata.version("marshmallow"))
 
 
 class MockHTTPError(Exception):
@@ -555,27 +551,6 @@ def test_required_with_custom_error(parser, web_request):
         parser.parse(args, web_request)
 
     assert "We need foo" in excinfo.value.messages["json"]["foo"]
-
-
-@pytest.mark.filterwarnings("ignore:Returning `False` from a validator is deprecated")
-@pytest.mark.skipif(
-    MARSHMALLOW_VERSION.major >= 4,
-    reason="marshmallow 4+ does not support validators returning False",
-)
-def test_required_with_custom_error_and_validation_error(parser, web_request):
-    web_request.json = {"foo": ""}
-    args = {
-        "foo": fields.Str(
-            required="We need foo",
-            validate=lambda s: len(s) > 1,
-            error_messages={"validator_failed": "foo required length is 3"},
-        )
-    }
-    with pytest.raises(ValidationError) as excinfo:
-        # Test that `validate` receives dictionary of args
-        parser.parse(args, web_request)
-
-    assert "foo required length is 3" in excinfo.value.args[0]["foo"]
 
 
 def test_full_input_validator_receives_nonascii_input(web_request):

--- a/tests/test_djangoparser.py
+++ b/tests/test_djangoparser.py
@@ -1,6 +1,5 @@
 import pytest
 
-from tests.apps.django_app import DJANGO_SUPPORTS_ASYNC
 from tests.apps.django_app.base.wsgi import application
 from webargs.testing import CommonTestCase
 
@@ -29,14 +28,8 @@ class TestDjangoParser(CommonTestCase):
         res = testapp.get("/echo_use_args_with_path_param_cbv/42?name=Fred")
         assert res.json == {"name": "Fred"}
 
-    @pytest.mark.skipif(
-        not DJANGO_SUPPORTS_ASYNC, reason="requires a django version with async support"
-    )
     def test_parse_querystring_args_async(self, testapp):
         assert testapp.get("/async_echo?name=Fred").json == {"name": "Fred"}
 
-    @pytest.mark.skipif(
-        not DJANGO_SUPPORTS_ASYNC, reason="requires a django version with async support"
-    )
     def test_async_use_args_decorator(self, testapp):
         assert testapp.get("/async_echo_use_args?name=Fred").json == {"name": "Fred"}

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -1,7 +1,7 @@
 import falcon.testing
 import pytest
 
-from tests.apps.falcon_app import FALCON_SUPPORTS_ASYNC, create_app, create_async_app
+from tests.apps.falcon_app import create_app, create_async_app
 from webargs.testing import CommonTestCase
 
 
@@ -73,17 +73,11 @@ class TestFalconParser(CommonTestCase):
         )
         assert res.json == {"name": "Fred"}
 
-    @pytest.mark.skipif(
-        not FALCON_SUPPORTS_ASYNC, reason="requires a falcon version with async support"
-    )
     def test_parse_querystring_args_async(self):
         app = create_async_app()
         client = falcon.testing.TestClient(app)
         assert client.simulate_get("/async_echo?name=Fred").json == {"name": "Fred"}
 
-    @pytest.mark.skipif(
-        not FALCON_SUPPORTS_ASYNC, reason="requires a falcon version with async support"
-    )
     def test_async_use_args_decorator(self):
         app = create_async_app()
         client = falcon.testing.TestClient(app)

--- a/tests/test_flaskparser.py
+++ b/tests/test_flaskparser.py
@@ -10,7 +10,7 @@ from webargs.core import json
 from webargs.flaskparser import abort, parser
 from webargs.testing import CommonTestCase
 
-from .apps.flask_app import FLASK_SUPPORTS_ASYNC, app
+from .apps.flask_app import app
 
 
 class TestFlaskParser(CommonTestCase):
@@ -71,53 +71,32 @@ class TestFlaskAsyncParser(CommonTestCase):
     def create_app(self):
         return app
 
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_parsing_view_args_async(self, testapp):
         res = testapp.get("/echo_view_arg_async/42")
         assert res.json == {"view_arg": 42}
 
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_parsing_invalid_view_arg_async(self, testapp):
         res = testapp.get("/echo_view_arg_async/foo", expect_errors=True)
         assert res.status_code == 422
         assert res.json == {"view_args": {"view_arg": ["Not a valid integer."]}}
 
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_use_args_with_view_args_parsing_async(self, testapp):
         res = testapp.get("/echo_view_arg_use_args_async/42")
         assert res.json == {"view_arg": 42}
 
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_use_args_on_a_method_view_async(self, testapp):
         res = testapp.post_json("/echo_method_view_use_args_async", {"val": 42})
         assert res.json == {"val": 42}
 
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_use_kwargs_on_a_method_view_async(self, testapp):
         res = testapp.post_json("/echo_method_view_use_kwargs_async", {"val": 42})
         assert res.json == {"val": 42}
 
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_use_kwargs_with_missing_data_async(self, testapp):
         res = testapp.post_json("/echo_use_kwargs_missing_async", {"username": "foo"})
         assert res.json == {"username": "foo"}
 
     # regression test for https://github.com/marshmallow-code/webargs/issues/145
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_nested_many_with_data_key_async(self, testapp):
         post_with_raw_fieldname_args = (
             "/echo_nested_many_data_key_async",
@@ -135,9 +114,6 @@ class TestFlaskAsyncParser(CommonTestCase):
         assert res.json == {}
 
     # regression test for https://github.com/marshmallow-code/webargs/issues/500
-    @pytest.mark.skipif(
-        not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask"
-    )
     def test_parsing_unexpected_headers_when_raising_async(self, testapp):
         res = testapp.get(
             "/echo_headers_raising_async",
@@ -178,7 +154,6 @@ def test_abort_called_on_validation_error(mock_abort):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(not FLASK_SUPPORTS_ASYNC, reason="requires async support in flask")
 async def test_abort_called_on_validation_error_async():
     with mock.patch("webargs.flaskparser.abort") as mock_abort:
         # error handling must raise an error to be valid

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -25,16 +25,6 @@ class BaseAsyncTestCase(tornado.testing.AsyncHTTPTestCase):
     # this isn't a real test case itself
     __test__ = False
 
-    # Workaround for https://github.com/pytest-dev/pytest/issues/12263.
-    #
-    # this was suggested by one of the pytest maintainers while a patch
-    # for Tornado is pending
-    #
-    # we may need it even after the patch, since we want to support testing on
-    # older Tornado versions until we drop support for them
-    def runTest(self):
-        pass
-
 
 name = "name"
 value = "value"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     lint
-    py{310,311,312,313,314}-marshmallow{3,4}
+    py{310,311,312,313,314}-marshmallow
     py314-marshmallowdev
     py310-lowest
     docs
@@ -9,8 +9,7 @@ envlist=
 [testenv]
 extras = tests
 deps =
-    marshmallow3: marshmallow>=3.0.0,<4.0.0
-    marshmallow4: marshmallow>=4.0.0,<5.0.0
+    marshmallow: marshmallow>=4.0.0,<5.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
     lowest: flask==3.1.0
     lowest: Django==5.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -12,27 +12,13 @@ deps =
     marshmallow3: marshmallow>=3.0.0,<4.0.0
     marshmallow4: marshmallow>=4.0.0,<5.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
-
-# for 'lowest', pin flask to 1.1.3 and markupsafe to 1.1.1
-# because flask 1.x does not set upper bounds on the versions of its dependencies
-# generally, we can't install just any version from 1.x -- only 1.1.3 and 1.1.4
-# markupsafe is a second-order dependency of flask (flask -> jinja2 -> markupsafe)
-# and must be pinned explicitly because jinja2 does not pin its dependencies in any
-# versions in its 2.x line
-# see:
-#   https://github.com/marshmallow-code/webargs/pull/694
-#   https://github.com/pallets/flask/pull/4047
-#   https://github.com/pallets/flask/issues/4455
-    lowest: flask==1.1.3
-    lowest: markupsafe==1.1.1
-# all non-flask frameworks
-    lowest: Django==2.2.0
+    lowest: flask==3.1.0
+    lowest: Django==5.2.0
     lowest: bottle==0.13.0
-    lowest: tornado==6.0.0
-    lowest: pyramid==1.9.1
-    lowest: falcon==2.0.0
-    lowest: aiohttp==3.0.8
-# pin marshmallow itself to the lowest supported version
+    lowest: tornado==6.5.0
+    lowest: pyramid==2.0.2
+    lowest: falcon==4.1.0
+    lowest: aiohttp==3.13.0
     lowest: marshmallow==3.13.0
 commands = pytest {posargs}
 


### PR DESCRIPTION
Closes #725.

I bumped to the latest minor, except for Pyramid for which it was pretty old and Python 3.10 and 3.11 support was added in subsequent patch release.