### PR TITLE
Temporarily pin `setuptools<82.0` for pyramid tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,12 @@ deps =
     lowest: falcon==4.1.0
     lowest: aiohttp==3.13.0
     lowest: marshmallow==3.13.0
+
+    # temporary pin: hold back `setuptools` so that `pyramid` testing works
+    # pyramid uses pkg_resources, which has been long deprecated and finally removed
+    #
+    # see https://github.com/Pylons/pyramid/issues/3731 for discussion within pyramid
+    setuptools < 82.0
 commands = pytest {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
`pyramid` uses `pkg_resources`, so we need a pin, at least for now.

It's done in `tox.ini` to be very lightweight.

---

I want to also try switching the test configuration so that we have a matrix
where each framework is independent, and all of them are declared as dependency
groups.

I think this will require adjustments to make the per-framework tests
conditional on their relevant framework being installed.
