### PR TITLE
Convert optional-dependencies to dependency-groups

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,12 +4,15 @@ sphinx:
 formats:
   - pdf
 build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.11"
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+  os: ubuntu-24.04
+  commands:
+    # setup uv
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    # setup tox + tox-uv
+    - uv tool install tox --with tox-uv --python "3.14" --managed-python
+    # setup the docs tox environment, but use `--notest` to skip commands
+    - uv tool run tox run -e docs --notest -vvv
+    # do the actual build step, to the RTD documented output directory
+    - uv tool run tox run -e docs --skip-pkg-install -q -- "${READTHEDOCS_OUTPUT}"/html -b dirhtml

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,12 +24,6 @@ webargs.multidictproxy
     :members:
 
 
-webargs.asyncparser
--------------------
-
-.. automodule:: webargs.asyncparser
-    :inherited-members:
-
 webargs.flaskparser
 -------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,18 @@ intersphinx_mapping = {
     "marshmallow": ("http://marshmallow.readthedocs.io/en/latest/", None),
 }
 
+autodoc_mock_imports = [
+    "aiohttp",
+    "bottle",
+    "django",
+    "falcon",
+    "flask",
+    "pyramid",
+    "tornado",
+    "webob",
+    "werkzeug",
+]
+
 
 # The master toctree document.
 master_doc = "index"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,27 +55,6 @@ Issues = "https://github.com/marshmallow-code/webargs/issues"
 Source = "https://github.com/marshmallow-code/webargs"
 Tidelift = "https://tidelift.com/subscription/pkg/pypi-webargs?utm_source=pypi-webargs&utm_medium=pypi"
 
-[project.optional-dependencies]
-frameworks = [
-  "Flask>=3.1.0",
-  "Django>=5.2.0",
-  "bottle>=0.13.0",
-  "tornado>=6.5.0",
-  "pyramid>=2.0.2",
-  "falcon>=4.1.0",
-  "aiohttp>=3.13.0",
-]
-tests = [
-  "webargs[frameworks]",
-  "pytest",
-  "pytest-asyncio",
-  "webtest==3.0.7",
-  "webtest-aiohttp==2.0.0",
-  "pytest-aiohttp>=0.3.0",
-  "packaging>=17.0",
-]
-dev = ["webargs[tests]", "tox", "pre-commit>=3.5,<5.0"]
-
 [build-system]
 requires = ["flit_core<4"]
 build-backend = "flit_core.buildapi"
@@ -87,6 +66,43 @@ docs = [
   "sphinx-issues==5.0.1",
   "furo==2025.12.19",
 ]
+
+tests = [
+  "pytest",
+  "pytest-asyncio",
+  "webtest==3.0.7",
+  "webtest-aiohttp==2.0.0",
+  "pytest-aiohttp>=0.3.0",
+  "packaging>=17.0",
+]
+test-flask = ["Flask>=3.1.0", {include-group = "tests"}]
+test-django = ["Django>=5.2.0", {include-group = "tests"}]
+test-bottle = ["bottle>=0.13.0", {include-group = "tests"}]
+test-tornado = ["tornado>=6.5.0", {include-group = "tests"}]
+test-pyramid = [
+    "pyramid>=2.0.2", {include-group = "tests"},
+    # temporary pin: hold back `setuptools` so that `pyramid` testing works
+    # pyramid uses pkg_resources, which has been long deprecated and finally removed
+    #
+    # see https://github.com/Pylons/pyramid/issues/3731 for discussion within pyramid
+    "setuptools < 82.0"
+]
+test-falcon = ["falcon>=4.1.0", {include-group = "tests"}]
+test-aiohttp = ["aiohttp>=3.13.0", {include-group = "tests"}]
+# for efficiency of testing, we define this group and test all frameworks at once, because it works
+# however, each is declared separately in case we ever encounter conflicts and need to break one off
+# from the rest of the group
+test-all-frameworks = [
+  {include-group = "test-flask"},
+  {include-group = "test-django"},
+  {include-group = "test-bottle"},
+  {include-group = "test-tornado"},
+  {include-group = "test-pyramid"},
+  {include-group = "test-falcon"},
+  {include-group = "test-aiohttp"},
+]
+
+dev = ["tox", "pre-commit>=3.5,<5.0", {include-group = "tests"}]
 
 [tool.flit.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,17 +74,19 @@ tests = [
   "pytest-aiohttp>=0.3.0",
   "packaging>=17.0",
 ]
-docs = [
-  "webargs[frameworks]",
-  "Sphinx==9.1.0",
-  "sphinx-issues==5.0.1",
-  "furo==2025.12.19",
-]
 dev = ["webargs[tests]", "tox", "pre-commit>=3.5,<5.0"]
 
 [build-system]
 requires = ["flit_core<4"]
 build-backend = "flit_core.buildapi"
+
+[dependency-groups]
+docs = [
+  "webargs",
+  "Sphinx==9.1.0",
+  "sphinx-issues==5.0.1",
+  "furo==2025.12.19",
+]
 
 [tool.flit.sdist]
 include = [

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ extras = frameworks
 commands = mypy src/ {posargs}
 
 [testenv:docs]
-extras = docs
+dependency_groups = docs
 commands = sphinx-build docs/ docs/_build {posargs}
 
 ; Below tasks are for development only (not run in CI)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist=
     docs
 
 [testenv]
-extras = tests
+dependency_groups = test-all-frameworks
 deps =
     marshmallow: marshmallow>=4.0.0,<5.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
@@ -19,12 +19,6 @@ deps =
     lowest: falcon==4.1.0
     lowest: aiohttp==3.13.0
     lowest: marshmallow==3.13.0
-
-    # temporary pin: hold back `setuptools` so that `pyramid` testing works
-    # pyramid uses pkg_resources, which has been long deprecated and finally removed
-    #
-    # see https://github.com/Pylons/pyramid/issues/3731 for discussion within pyramid
-    setuptools < 82.0
 commands = pytest {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
I started this work with the thought that there's been a long-standing maintenance risk for `webargs` that I wanted to mitigate.
If our frameworks ever become incompatible with one another, we won't be able to install them all at once for doc builds or testing.

However, after more thought and evaluation, actually *doing* the testing isolated per framework would make CI slower and less energy efficient, for unclear gain.
Instead of making the change to test each framework independently, this changeset prepares for the possibility of doing the testing separately, but without acting on it.

For docs, however, it is a little bit worthwhile to use sphinx autodoc's import-mock feature to remove the dependency on frameworks.
Not only does this make our doc builds keep working if the frameworks ever cause issues, it also makes doc builds more efficient.

As a bonus inclusion, in order to make RTD builds use the newly defined `docs` dependency group, convert to a `uv`-based doc build which reuses our tox environment.
