### PR TITLE
Fix RTD builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands = mypy src/ {posargs}
 
 [testenv:docs]
 dependency_groups = docs
-commands = sphinx-build docs/ docs/_build {posargs}
+commands = sphinx-build docs/ {posargs:docs/_build}
 
 ; Below tasks are for development only (not run in CI)
 


### PR DESCRIPTION
Sphinx builds are failing becuase the command is passing the build directory argument incorrectly