### PR TITLE
Fix tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,14 @@
+import asyncio
+
 import pytest
 
 pytest.register_assert_rewrite("webargs.testing")
+
+
+@pytest.fixture
+def current_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    asyncio.set_event_loop(None)
+    loop.close()

--- a/tests/test_falconparser.py
+++ b/tests/test_falconparser.py
@@ -73,11 +73,13 @@ class TestFalconParser(CommonTestCase):
         )
         assert res.json == {"name": "Fred"}
 
+    @pytest.mark.usefixtures("current_loop")
     def test_parse_querystring_args_async(self):
         app = create_async_app()
         client = falcon.testing.TestClient(app)
         assert client.simulate_get("/async_echo?name=Fred").json == {"name": "Fred"}
 
+    @pytest.mark.usefixtures("current_loop")
     def test_async_use_args_decorator(self):
         app = create_async_app()
         client = falcon.testing.TestClient(app)

--- a/tests/test_tornadoparser.py
+++ b/tests/test_tornadoparser.py
@@ -139,11 +139,12 @@ class TestJSONArgs:
         result = parser.load_json(request, author_schema)
         assert result == {}
 
+    @pytest.mark.usefixtures("current_loop")
     def test_it_should_handle_type_error_on_load_json(self):
         # but this is different from the test above where the payload was valid
         # and empty -- missing vs {}
-        # NOTE: `event_loop` is the pytest-aiohttp event loop fixture, but it's
-        # important to get an event loop here so that we can construct a future
+        # NOTE: the `current_loop` fixture sets a current event loop,
+        # which is required here so that we can construct a future
         request = make_request(
             body=tornado.concurrent.Future(),
             headers={"Content-Type": "application/json"},


### PR DESCRIPTION
Implicit event loop was removed from pytest-asyncio, so add a new fixture that can be used by the synchronous ASGI falcon tests