### PR TITLE
Modernize aiohttpparser docstring example (remove removed asyncio.coroutine)

### DIFF
--- a/src/webargs/aiohttpparser.py
+++ b/src/webargs/aiohttpparser.py
@@ -2,7 +2,6 @@
 
 Example: ::
 
-    import asyncio
     from aiohttp import web
 
     from webargs import fields
@@ -12,9 +11,8 @@ Example: ::
     hello_args = {"name": fields.Str(required=True)}
 
 
-    @asyncio.coroutine
     @use_args(hello_args)
-    def index(request, args):
+    async def index(request, args):
         return web.Response(body="Hello {}".format(args["name"]).encode("utf-8"))
 
 


### PR DESCRIPTION
## Summary

The `aiohttpparser` module docstring's usage example decorates a plain generator function with `@asyncio.coroutine`:

```python
import asyncio
...

@asyncio.coroutine
@use_args(hello_args)
def index(request, args):
    return web.Response(body="Hello {}".format(args["name"]).encode("utf-8"))
```

`asyncio.coroutine` was deprecated in Python 3.8 and **removed in Python 3.11**. webargs declares support for Python 3.10–3.14 (`requires-python = ">=3.10"`), and on 3.11+ there is no `asyncio.coroutine`, so anyone copy-pasting this example hits:

```
AttributeError: module 'asyncio' has no attribute 'coroutine'
```

The parser's own implementation already uses `async def` / `await`, and `examples/aiohttp_example.py` uses `async def index(request, args)`. The docstring is just stale.

## Fix

Modernize the example to `async def` (matching the repo's own example) and drop the now-unused `import asyncio`. Docstring-only change; no runtime code touched.

```python
from aiohttp import web

from webargs import fields
from webargs.aiohttpparser import use_args


hello_args = {"name": fields.Str(required=True)}


@use_args(hello_args)
async def index(request, args):
    return web.Response(body="Hello {}".format(args["name"]).encode("utf-8"))
```

## Verification

- Confirmed `asyncio.coroutine` does not exist on Python 3.11+ (`hasattr(asyncio, "coroutine")` is `False`).
- `import webargs.aiohttpparser` succeeds after the change.
- Extracted the new docstring example and `ast.parse`d it — valid Python.
